### PR TITLE
refactor(analyzer): introduce concept analyser to reduce alert noise

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,22 +6,9 @@ The checks are run against a Grafana instance, which is configured with a Promet
 
 ## Usage
 
-### Pulse Check All Clients
+### Pulse Check
 
-```bash
-docker run -e GRAFANA_SERVICE_TOKEN=your_token \
-          -e DISCORD_BOT_TOKEN=your_token \
-          -e OPENROUTER_API_KEY=optional_key \
-          ethpandaops/panda-pulse:0.0.2 \
-          --discord-channel CHANNEL_ID \
-          --network NETWORK_NAME
-```
-
-### Pulse Check Specific Client
-
-You can also pass in a target client to scope the checks + notification. 
-
-This can be done with `--ethereum-cl` or `--ethereum-el`:
+Run by passing in a network name, a discord channel ID and one of `--ethereum-cl` or `--ethereum-el`.
 
 ```bash
 docker run -e GRAFANA_SERVICE_TOKEN=your_token \

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -51,19 +51,25 @@ func main() {
 				return fmt.Errorf("DISCORD_BOT_TOKEN environment variable is required")
 			}
 
-			// Check for mutually exclusive flags.
-			if cmd.Flags().Changed("ethereum-cl") && cmd.Flags().Changed("ethereum-el") {
+			// We enforce that one of --ethereum-cl or --ethereum-el is specified.
+			clSpecified := cmd.Flags().Changed("ethereum-cl")
+			elSpecified := cmd.Flags().Changed("ethereum-el")
+
+			if !clSpecified && !elSpecified {
+				return fmt.Errorf("must specify either --ethereum-cl or --ethereum-el")
+			}
+
+			if clSpecified && elSpecified {
 				return fmt.Errorf("cannot specify both --ethereum-cl and --ethereum-el flags")
 			}
 
-			// Validate client flags.
-			if cmd.Flags().Changed("ethereum-cl") {
+			if clSpecified {
 				if err := validateClient(cfg.ConsensusNode, true); err != nil {
 					return err
 				}
 			}
 
-			if cmd.Flags().Changed("ethereum-el") {
+			if elSpecified {
 				if err := validateClient(cfg.ExecutionNode, false); err != nil {
 					return err
 				}

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -1,3 +1,20 @@
+/*
+Package analyzer provides functionality for analyzing the health relationships between Ethereum consensus layer (CL)
+and execution layer (EL) clients. It helps identify root causes of client failures by detecting patterns where:
+
+1. For CL clients: If an EL client is failing with multiple CL clients, it's likely the root cause
+2. For EL clients: If the target EL client is failing with multiple CL clients, it's likely the root cause
+
+The analyzer tracks client relationships and their health status, distinguishing between explained issues
+(traced back to a root cause) and unexplained issues that may need further investigation.
+
+Example usage:
+
+	analyzer := NewAnalyzer("geth", ClientTypeEL)
+	analyzer.AddNodeStatus("lighthouse-geth-1", false)
+	analyzer.AddNodeStatus("prysm-geth-1", false)
+	result := analyzer.Analyze()
+*/
 package analyzer
 
 import (
@@ -6,11 +23,35 @@ import (
 	"strings"
 )
 
+const (
+	// MinFailuresForRootCause is the minimum number of failures needed to consider something a root cause.
+	MinFailuresForRootCause = 2
+)
+
 // Analyzer is a struct that analyzes the status of a client.
 type Analyzer struct {
+	// nodeStatusMap tracks the health status of all client pairs (CL-EL relationships).
+	// The map key is a ClientPair (e.g., lighthouse-geth), and the value is a list of NodeStatus
+	// for all instances of that pair.
 	nodeStatusMap NodeStatusMap
-	targetClient  string
-	clientType    ClientType
+	// targetClient is the name of the client we're analyzing (e.g., "geth", "lighthouse").
+	targetClient string
+	// clientType indicates whether we're analyzing a CL or EL client.
+	clientType ClientType
+}
+
+// clientStatusTracker tracks the health status and relationships of a client.
+type clientStatusTracker struct {
+	// totalPeers is the total number of peer relationships this client has.
+	// e.g., for an EL client, this would be the number of CL clients it pairs with.
+	totalPeers int
+	// failingPeers is the count of failing peer relationships.
+	// Used to track how many peers are having issues with this client.
+	failingPeers int
+	// failingList contains the names of peers that are failing with this client.
+	// e.g., for an EL client, this would be the list of CL client names that are failing.
+	// Used for logging and evidence gathering when determining root causes.
+	failingList []string
 }
 
 // NewAnalyzer creates a new Analyzer.
@@ -22,9 +63,46 @@ func NewAnalyzer(targetClient string, clientType ClientType) *Analyzer {
 	}
 }
 
+// Analyze analyzes the status of a client.
+func (a *Analyzer) Analyze() *AnalysisResult {
+	log.Printf("\n=== Analyzing %s (%s)", a.targetClient, a.clientType)
+
+	result := &AnalysisResult{
+		RootCause:         make([]string, 0),
+		UnexplainedIssues: make([]string, 0),
+		AffectedNodes:     make(map[string][]string),
+		RootCauseEvidence: make(map[string]string),
+	}
+
+	var (
+		rootCauses []string
+		evidence   map[string]string
+	)
+
+	switch a.clientType {
+	case ClientTypeCL:
+		status := a.analyzeClientRelationships(ClientTypeCL)
+		rootCauses, evidence = a.findRootCausesForCL(status)
+	case ClientTypeEL:
+		rootCauses, evidence = a.findRootCausesForEL()
+	default:
+		// If we made it here, we have bigger problems.
+		log.Printf("  - Unknown client type: %s", a.clientType)
+	}
+
+	result.RootCause = rootCauses
+	result.RootCauseEvidence = evidence
+	result.UnexplainedIssues = a.findUnexplainedIssues(rootCauses)
+
+	a.logAnalysisResults(result)
+
+	return result
+}
+
 // AddNodeStatus adds a node status to the analyzer.
 func (a *Analyzer) AddNodeStatus(nodeName string, isHealthy bool) {
-	pair := ParseClientPair(nodeName)
+	pair := parseClientPair(nodeName)
+
 	if _, exists := a.nodeStatusMap[pair]; !exists {
 		a.nodeStatusMap[pair] = make([]NodeStatus, 0)
 	}
@@ -35,130 +113,209 @@ func (a *Analyzer) AddNodeStatus(nodeName string, isHealthy bool) {
 	})
 }
 
-// Analyze analyzes the status of the client.
-func (a *Analyzer) Analyze() *AnalysisResult {
-	result := &AnalysisResult{
-		RootCause:         make([]string, 0),
-		UnexplainedIssues: make([]string, 0),
-		AffectedNodes:     make(map[string][]string),
-		RootCauseEvidence: make(map[string]string),
+// getClientAndPeerNames gets the client and peer names.
+func (a *Analyzer) getClientAndPeerNames(pair ClientPair, targetType ClientType) (client, peer string) {
+	if targetType == ClientTypeCL {
+		return pair.ELClient, pair.CLClient
 	}
 
-	log.Printf("\n=== Analyzing %s (%s)", a.targetClient, a.clientType)
+	return pair.CLClient, pair.ELClient
+}
 
-	// For CL clients, check if any EL clients are having widespread issues. For example, if
-	// we consistently see the same EL clients failing across multiple CL clients, we can
-	// reasonably conclude that the EL clients are the root cause in this scenario.
-	elStatus := make(map[string]struct {
-		totalCLs    int
-		failingCLs  int
-		failingList []string
-	})
+// isTargetClientIssue checks if the issue is related to the target client.
+func (a *Analyzer) isTargetClientIssue(pair ClientPair) bool {
+	switch a.clientType {
+	case ClientTypeCL:
+		return pair.CLClient == a.targetClient
+	case ClientTypeEL:
+		return pair.ELClient == a.targetClient
+	default:
+		return false
+	}
+}
 
-	// First identify root causes.
-	if a.clientType == ClientTypeCL {
-		// Count total CL clients for each EL.
-		for pair := range a.nodeStatusMap {
-			if _, exists := elStatus[pair.ELClient]; !exists {
-				elStatus[pair.ELClient] = struct {
-					totalCLs    int
-					failingCLs  int
-					failingList []string
-				}{0, 0, make([]string, 0)}
-			}
-
-			status := elStatus[pair.ELClient]
-			status.totalCLs++
-			elStatus[pair.ELClient] = status
-		}
-
-		// Then count failing relationships.
-		for pair, statuses := range a.nodeStatusMap {
-			hasIssue := false
-
-			for _, status := range statuses {
-				if !status.IsHealthy {
-					hasIssue = true
-
-					break
-				}
-			}
-
-			if hasIssue {
-				status := elStatus[pair.ELClient]
-				status.failingCLs++
-
-				if !contains(status.failingList, pair.CLClient) {
-					status.failingList = append(status.failingList, pair.CLClient)
-				}
-
-				elStatus[pair.ELClient] = status
-			}
-		}
-
-		// Identify EL clients that are failing with multiple CL clients.
-		for el, status := range elStatus {
-			if el == "" {
-				continue // Skip empty client names.
-			}
-
-			log.Printf(
-				"  - %s is failing with CL clients: %s",
-				el,
-				strings.Join(status.failingList, ", "),
-			)
-
-			if len(status.failingList) > 2 {
-				result.RootCause = append(result.RootCause, el)
-				result.RootCauseEvidence[el] = fmt.Sprintf(
-					"Failing with %d CL clients: %s",
-					len(status.failingList),
-					strings.Join(status.failingList, ", "),
-				)
-			}
+// hasHealthIssue checks if the node has a health issue.
+func (a *Analyzer) hasHealthIssue(statuses []NodeStatus) bool {
+	for _, status := range statuses {
+		if !status.IsHealthy {
+			return true
 		}
 	}
 
-	// Now identify unexplained issues.
+	return false
+}
+
+// analyzeClientRelationships analyzes the relationships between CL and EL clients counting total peers
+// and any failing relationships we may have.
+func (a *Analyzer) analyzeClientRelationships(targetType ClientType) map[string]*clientStatusTracker {
+	status := make(map[string]*clientStatusTracker)
+
+	// Count total peers.
+	for pair := range a.nodeStatusMap {
+		clientName, _ := a.getClientAndPeerNames(pair, targetType)
+		if _, exists := status[clientName]; !exists {
+			status[clientName] = &clientStatusTracker{}
+		}
+
+		status[clientName].totalPeers++
+	}
+
+	// Count failing relationships.
 	for pair, statuses := range a.nodeStatusMap {
+		if !a.hasHealthIssue(statuses) {
+			continue
+		}
+
+		clientName, peerName := a.getClientAndPeerNames(pair, targetType)
+		if status[clientName] != nil {
+			status[clientName].addFailure(peerName)
+		}
+	}
+
+	return status
+}
+
+// findTargetFailures finds the nodes that are failing for our target client.
+func (a *Analyzer) findTargetFailures() []string {
+	failures := make([]string, 0)
+
+	for pair, statuses := range a.nodeStatusMap {
+		if !a.isTargetClientIssue(pair) {
+			continue
+		}
+
 		for _, status := range statuses {
 			if !status.IsHealthy {
-				// Only consider issues with our target client. We don't want to be including
-				// noise about other clients in the individual client notifications.
-				if (a.clientType == ClientTypeCL && pair.CLClient == a.targetClient) ||
-					(a.clientType == ClientTypeEL && pair.ELClient == a.targetClient) {
-					isExplained := false
-
-					for _, rootCause := range result.RootCause {
-						if (a.clientType == ClientTypeCL && pair.ELClient == rootCause) ||
-							(a.clientType == ClientTypeEL && pair.CLClient == rootCause) {
-							isExplained = true
-
-							break
-						}
-					}
-
-					if !isExplained {
-						result.UnexplainedIssues = append(result.UnexplainedIssues, status.Name)
-					}
-				}
+				failures = append(failures, status.Name)
 			}
 		}
 	}
 
-	result.UnexplainedIssues = unique(result.UnexplainedIssues)
+	return failures
+}
+
+// findUnexplainedIssues finds the nodes that are failing for our target client but are not explained by the root causes.
+func (a *Analyzer) findUnexplainedIssues(rootCauses []string) []string {
+	unexplained := make([]string, 0)
+
+	for pair, statuses := range a.nodeStatusMap {
+		if !a.isTargetClientIssue(pair) {
+			continue
+		}
+
+		for _, status := range statuses {
+			if !status.IsHealthy && !a.isIssueExplained(pair, rootCauses) {
+				unexplained = append(unexplained, status.Name)
+			}
+		}
+	}
+
+	return unique(unexplained)
+}
+
+// isIssueExplained checks if the issue is explained by being classified as a root cause.
+func (a *Analyzer) isIssueExplained(pair ClientPair, rootCauses []string) bool {
+	for _, rootCause := range rootCauses {
+		// If we're analyzing an EL client and it's the root cause, all its "issues" are explained.
+		if a.clientType == ClientTypeEL && rootCause == a.targetClient {
+			return true
+		}
+
+		// Now check if the client is failing due to it being a root cause.
+		switch a.clientType {
+		case ClientTypeCL:
+			if pair.ELClient == rootCause {
+				return true
+			}
+		case ClientTypeEL:
+			if pair.CLClient == rootCause {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// findRootCausesForCL finds the root causes for the CL client.
+func (a *Analyzer) findRootCausesForCL(status map[string]*clientStatusTracker) ([]string, map[string]string) {
+	var (
+		rootCauses = make([]string, 0)
+		evidence   = make(map[string]string)
+	)
+
+	for el, stat := range status {
+		if el == "" {
+			continue
+		}
+
+		log.Printf(
+			"  - %s is failing with CL clients: %s",
+			el,
+			strings.Join(stat.failingList, ", "),
+		)
+
+		if len(stat.failingList) > MinFailuresForRootCause {
+			rootCauses = append(rootCauses, el)
+			evidence[el] = fmt.Sprintf(
+				"Failing with %d CL clients: %s",
+				len(stat.failingList),
+				strings.Join(stat.failingList, ", "),
+			)
+		}
+	}
+
+	return rootCauses, evidence
+}
+
+// findRootCausesForEL finds any root causes for the EL client.
+func (a *Analyzer) findRootCausesForEL() ([]string, map[string]string) {
+	var (
+		rootCauses = make([]string, 0)
+		evidence   = make(map[string]string)
+	)
+
+	targetFailures := a.findTargetFailures()
+
+	if len(targetFailures) > MinFailuresForRootCause {
+		rootCauses = append(rootCauses, a.targetClient)
+		evidence[a.targetClient] = fmt.Sprintf(
+			"Failing with %d nodes: %s",
+			len(targetFailures),
+			strings.Join(targetFailures, ", "),
+		)
+	}
+
+	return rootCauses, evidence
+}
+
+// logAnalysisResults logs the analysis results.
+func (a *Analyzer) logAnalysisResults(result *AnalysisResult) {
+	if len(result.UnexplainedIssues) == 0 && len(result.RootCause) == 0 {
+		log.Printf("  - No issues to analyze")
+
+		return
+	}
+
+	for _, cause := range result.RootCause {
+		log.Printf("  - Root cause identified: %s (%s)", cause, result.RootCauseEvidence[cause])
+	}
+
 	for _, issue := range result.UnexplainedIssues {
 		log.Printf("  - %s (unexplained issue)", issue)
 	}
-
-	if len(elStatus) == 0 && len(result.UnexplainedIssues) == 0 {
-		log.Printf("  - No issues to analyze")
-	}
-
-	return result
 }
 
-// Helper function to check if a string slice contains a value.
+// addFailure adds a failure to the client status tracker.
+func (c *clientStatusTracker) addFailure(peerName string) {
+	c.failingPeers++
+
+	if !contains(c.failingList, peerName) {
+		c.failingList = append(c.failingList, peerName)
+	}
+}
+
+// contains checks if a string slice contains a value.
 func contains(slice []string, str string) bool {
 	for _, v := range slice {
 		if v == str {
@@ -169,7 +326,7 @@ func contains(slice []string, str string) bool {
 	return false
 }
 
-// Helper function to deduplicate a string slice.
+// unique deduplicates a string slice.
 func unique(slice []string) []string {
 	var (
 		seen   = make(map[string]bool)

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -1,0 +1,188 @@
+package analyzer
+
+import (
+	"fmt"
+	"log"
+	"strings"
+)
+
+// Analyzer is a struct that analyzes the status of a client.
+type Analyzer struct {
+	nodeStatusMap NodeStatusMap
+	targetClient  string
+	clientType    ClientType
+}
+
+// NewAnalyzer creates a new Analyzer.
+func NewAnalyzer(targetClient string, clientType ClientType) *Analyzer {
+	return &Analyzer{
+		nodeStatusMap: make(NodeStatusMap),
+		targetClient:  targetClient,
+		clientType:    clientType,
+	}
+}
+
+// AddNodeStatus adds a node status to the analyzer.
+func (a *Analyzer) AddNodeStatus(nodeName string, isHealthy bool) {
+	pair := ParseClientPair(nodeName)
+	if _, exists := a.nodeStatusMap[pair]; !exists {
+		a.nodeStatusMap[pair] = make([]NodeStatus, 0)
+	}
+
+	a.nodeStatusMap[pair] = append(a.nodeStatusMap[pair], NodeStatus{
+		Name:      nodeName,
+		IsHealthy: isHealthy,
+	})
+}
+
+// Analyze analyzes the status of the client.
+func (a *Analyzer) Analyze() *AnalysisResult {
+	result := &AnalysisResult{
+		RootCause:         make([]string, 0),
+		UnexplainedIssues: make([]string, 0),
+		AffectedNodes:     make(map[string][]string),
+		RootCauseEvidence: make(map[string]string),
+	}
+
+	log.Printf("\n=== Analyzing %s (%s)", a.targetClient, a.clientType)
+
+	// For CL clients, check if any EL clients are having widespread issues. For example, if
+	// we consistently see the same EL clients failing across multiple CL clients, we can
+	// reasonably conclude that the EL clients are the root cause in this scenario.
+	elStatus := make(map[string]struct {
+		totalCLs    int
+		failingCLs  int
+		failingList []string
+	})
+
+	// First identify root causes.
+	if a.clientType == ClientTypeCL {
+		// Count total CL clients for each EL.
+		for pair := range a.nodeStatusMap {
+			if _, exists := elStatus[pair.ELClient]; !exists {
+				elStatus[pair.ELClient] = struct {
+					totalCLs    int
+					failingCLs  int
+					failingList []string
+				}{0, 0, make([]string, 0)}
+			}
+
+			status := elStatus[pair.ELClient]
+			status.totalCLs++
+			elStatus[pair.ELClient] = status
+		}
+
+		// Then count failing relationships.
+		for pair, statuses := range a.nodeStatusMap {
+			hasIssue := false
+
+			for _, status := range statuses {
+				if !status.IsHealthy {
+					hasIssue = true
+
+					break
+				}
+			}
+
+			if hasIssue {
+				status := elStatus[pair.ELClient]
+				status.failingCLs++
+
+				if !contains(status.failingList, pair.CLClient) {
+					status.failingList = append(status.failingList, pair.CLClient)
+				}
+
+				elStatus[pair.ELClient] = status
+			}
+		}
+
+		// Identify EL clients that are failing with multiple CL clients.
+		for el, status := range elStatus {
+			if el == "" {
+				continue // Skip empty client names.
+			}
+
+			log.Printf(
+				"  - %s is failing with CL clients: %s",
+				el,
+				strings.Join(status.failingList, ", "),
+			)
+
+			if len(status.failingList) > 2 {
+				result.RootCause = append(result.RootCause, el)
+				result.RootCauseEvidence[el] = fmt.Sprintf(
+					"Failing with %d CL clients: %s",
+					len(status.failingList),
+					strings.Join(status.failingList, ", "),
+				)
+			}
+		}
+	}
+
+	// Now identify unexplained issues.
+	for pair, statuses := range a.nodeStatusMap {
+		for _, status := range statuses {
+			if !status.IsHealthy {
+				// Only consider issues with our target client. We don't want to be including
+				// noise about other clients in the individual client notifications.
+				if (a.clientType == ClientTypeCL && pair.CLClient == a.targetClient) ||
+					(a.clientType == ClientTypeEL && pair.ELClient == a.targetClient) {
+					isExplained := false
+
+					for _, rootCause := range result.RootCause {
+						if (a.clientType == ClientTypeCL && pair.ELClient == rootCause) ||
+							(a.clientType == ClientTypeEL && pair.CLClient == rootCause) {
+							isExplained = true
+
+							break
+						}
+					}
+
+					if !isExplained {
+						result.UnexplainedIssues = append(result.UnexplainedIssues, status.Name)
+					}
+				}
+			}
+		}
+	}
+
+	result.UnexplainedIssues = unique(result.UnexplainedIssues)
+	for _, issue := range result.UnexplainedIssues {
+		log.Printf("  - %s (unexplained issue)", issue)
+	}
+
+	if len(elStatus) == 0 && len(result.UnexplainedIssues) == 0 {
+		log.Printf("  - No issues to analyze")
+	}
+
+	return result
+}
+
+// Helper function to check if a string slice contains a value.
+func contains(slice []string, str string) bool {
+	for _, v := range slice {
+		if v == str {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Helper function to deduplicate a string slice.
+func unique(slice []string) []string {
+	var (
+		seen   = make(map[string]bool)
+		result = make([]string, 0)
+	)
+
+	for _, str := range slice {
+		if !seen[str] {
+			seen[str] = true
+
+			result = append(result, str)
+		}
+	}
+
+	return result
+}

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -1,6 +1,6 @@
 /*
-Package analyzer provides functionality for analyzing the health relationships between Ethereum consensus layer (CL)
-and execution layer (EL) clients. It helps identify root causes of client failures by detecting patterns where:
+Package analyzer provides functionality for analyzing the health relationships between CL and EL clients.
+It helps identify root causes of client failures by detecting patterns where:
 
 1. For CL clients: If an EL client is failing with multiple CL clients, it's likely the root cause
 2. For EL clients: If the target EL client is failing with multiple CL clients, it's likely the root cause

--- a/pkg/analyzer/analyzer_test.go
+++ b/pkg/analyzer/analyzer_test.go
@@ -1,0 +1,122 @@
+package analyzer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAnalyzer_RootCauseDetection(t *testing.T) {
+	tests := []struct {
+		name             string
+		targetClient     string
+		clientType       ClientType
+		nodes            map[string]bool // map[nodeName]isHealthy
+		wantRootCause    []string
+		wantUnexplained  []string
+		wantNotification bool
+	}{
+		{
+			name:         "EL client failing with multiple CL clients should be classed as root cause",
+			targetClient: "nimbusel",
+			clientType:   ClientTypeEL,
+			nodes: map[string]bool{
+				"grandine-nimbusel-1":   false,
+				"lighthouse-nimbusel-1": false,
+				"lodestar-nimbusel-1":   false,
+				"nimbus-nimbusel-1":     false,
+				"prysm-nimbusel-1":      false,
+				"teku-nimbusel-1":       false,
+				// Add some healthy nodes with other EL clients to spice things up.
+				"lighthouse-geth-1": true,
+				"prysm-geth-1":      true,
+				"teku-nethermind-1": true,
+			},
+			wantRootCause:    []string{"nimbusel"},
+			wantUnexplained:  []string{}, // These should be explained by nimbusel being root cause.
+			wantNotification: true,       // Should notify as the targetClient itself is the root cause.
+		},
+		{
+			name:         "CL client with single EL issue should not be classed as root cause",
+			targetClient: "grandine",
+			clientType:   ClientTypeCL,
+			nodes: map[string]bool{
+				"grandine-erigon-1":     false,
+				"grandine-geth-1":       true,
+				"grandine-nethermind-1": true,
+				"lighthouse-erigon-1":   true,
+				"prysm-erigon-1":        true,
+			},
+			wantRootCause:    []string{},
+			wantUnexplained:  []string{"grandine-erigon-1"},
+			wantNotification: true, // Should notify as it has unexplained issue (grandine-erigon-1).
+		},
+		{
+			name:         "Multiple CL clients failing with same EL should classify EL as root cause",
+			targetClient: "lighthouse",
+			clientType:   ClientTypeCL,
+			nodes: map[string]bool{
+				"grandine-ethereumjs-1":   false,
+				"lighthouse-ethereumjs-1": false,
+				"lodestar-ethereumjs-1":   false,
+				"nimbus-ethereumjs-1":     false,
+				"prysm-ethereumjs-1":      false,
+				// Add some healthy nodes with other CL clients to ensure we filter them out nicely.
+				"lighthouse-geth-1":       true,
+				"lighthouse-nethermind-1": true,
+			},
+			wantRootCause:    []string{"ethereumjs"},
+			wantUnexplained:  []string{},
+			wantNotification: false, // Should not notify as issues are explained (root cause is ethereumjs).
+		},
+		{
+			name:         "No notification needed when all nodes are healthy",
+			targetClient: "lighthouse",
+			clientType:   ClientTypeCL,
+			nodes: map[string]bool{
+				"lighthouse-geth-1":       true,
+				"lighthouse-nethermind-1": true,
+				"lighthouse-besu-1":       true,
+			},
+			wantRootCause:    []string{},
+			wantUnexplained:  []string{},
+			wantNotification: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := NewAnalyzer(tt.targetClient, tt.clientType)
+
+			// Add all node statuses.
+			for nodeName, isHealthy := range tt.nodes {
+				a.AddNodeStatus(nodeName, isHealthy)
+			}
+
+			// Run analysis.
+			result := a.Analyze()
+
+			// Check root causes.
+			assert.ElementsMatch(t, tt.wantRootCause, result.RootCause, "root causes don't match")
+
+			// Check unexplained issues.
+			assert.ElementsMatch(t, tt.wantUnexplained, result.UnexplainedIssues, "unexplained issues don't match")
+
+			// Check if notification would be sent.
+			shouldNotify := len(result.UnexplainedIssues) > 0
+			for _, rc := range result.RootCause {
+				if rc == tt.targetClient {
+					shouldNotify = true
+
+					break
+				}
+			}
+			assert.Equal(t, tt.wantNotification, shouldNotify, "notification decision incorrect")
+
+			// If root causes were found, verify we have evidence.
+			for _, rc := range result.RootCause {
+				assert.NotEmpty(t, result.RootCauseEvidence[rc], "missing evidence for root cause %s", rc)
+			}
+		})
+	}
+}

--- a/pkg/analyzer/types.go
+++ b/pkg/analyzer/types.go
@@ -38,8 +38,8 @@ func (cp ClientPair) String() string {
 	return fmt.Sprintf("%s-%s", cp.CLClient, cp.ELClient)
 }
 
-// ParseClientPair parses a node name into CL and EL clients.
-func ParseClientPair(nodeName string) ClientPair {
+// parseClientPair parses a node name into CL and EL clients.
+func parseClientPair(nodeName string) ClientPair {
 	// Remove any network prefix if it exists
 	parts := strings.Split(nodeName, "-")
 	if len(parts) < 2 {

--- a/pkg/analyzer/types.go
+++ b/pkg/analyzer/types.go
@@ -1,0 +1,71 @@
+package analyzer
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ClientType represents the type of client.
+type ClientType string
+
+const (
+	ClientTypeEL ClientType = "EL"
+	ClientTypeCL ClientType = "CL"
+)
+
+// NodeStatus represents the status of a node.
+type NodeStatus struct {
+	Name      string
+	IsHealthy bool
+}
+
+// AnalysisResult is the result of the analysis.
+type AnalysisResult struct {
+	RootCause         []string            // List of clients determined to be root cause.
+	UnexplainedIssues []string            // List of issues that can't be explained by root cause.
+	AffectedNodes     map[string][]string // Map of issue type to affected nodes.
+	RootCauseEvidence map[string]string   // Evidence for why each root cause was determined.
+}
+
+// ClientPair represents a CL-EL client combination.
+type ClientPair struct {
+	CLClient string
+	ELClient string
+}
+
+// String returns the string representation of a ClientPair.
+func (cp ClientPair) String() string {
+	return fmt.Sprintf("%s-%s", cp.CLClient, cp.ELClient)
+}
+
+// ParseClientPair parses a node name into CL and EL clients.
+func ParseClientPair(nodeName string) ClientPair {
+	// Remove any network prefix if it exists
+	parts := strings.Split(nodeName, "-")
+	if len(parts) < 2 {
+		return ClientPair{}
+	}
+
+	// Find the CL and EL parts
+	// Format is typically: [network]-[cl_client]-[el_client]-[number]
+	// or: [cl_client]-[el_client]-[number]
+	var clClient, elClient string
+
+	if len(parts) >= 4 && strings.HasPrefix(nodeName, "pectra-devnet-6-") {
+		// Format: pectra-devnet-6-cl-el-number.
+		clClient = parts[len(parts)-3]
+		elClient = parts[len(parts)-2]
+	} else if len(parts) >= 3 {
+		// Format: cl-el-number.
+		clClient = parts[0]
+		elClient = parts[1]
+	}
+
+	return ClientPair{
+		CLClient: clClient,
+		ELClient: elClient,
+	}
+}
+
+// NodeStatusMap tracks the status of nodes by client pair.
+type NodeStatusMap map[ClientPair][]NodeStatus

--- a/pkg/checks/checks.go
+++ b/pkg/checks/checks.go
@@ -146,7 +146,7 @@ func (r *defaultRunner) RunChecks(ctx context.Context, cfg Config) ([]*Result, *
 			}
 
 			// Only include result if it has affected nodes for our target client. We don't want
-			// to be including noisy about other clients in the notification.
+			// to be including noise about other clients in the notification.
 			if len(filteredResult.AffectedNodes) > 0 {
 				// Copy and filter details.
 				for k, v := range result.Details {

--- a/pkg/checks/checks.go
+++ b/pkg/checks/checks.go
@@ -3,17 +3,22 @@ package checks
 import (
 	"context"
 	"fmt"
+	"log"
+	"strings"
 	"time"
+
+	"github.com/ethpandaops/panda-pulse/pkg/analyzer"
 )
 
 // Result represents the outcome of a health check.
 type Result struct {
-	Name        string
-	Category    Category
-	Status      Status
-	Description string
-	Timestamp   time.Time
-	Details     map[string]interface{}
+	Name          string
+	Category      Category
+	Status        Status
+	Description   string
+	Timestamp     time.Time
+	Details       map[string]interface{}
+	AffectedNodes []string
 }
 
 // Status represents the status of a check.
@@ -50,7 +55,7 @@ type Runner interface {
 	// RegisterCheck adds a check to the runner.
 	RegisterCheck(check Check)
 	// RunChecks executes all registered checks.
-	RunChecks(ctx context.Context, cfg Config) ([]*Result, error)
+	RunChecks(ctx context.Context, cfg Config) ([]*Result, *analyzer.AnalysisResult, error)
 }
 
 // defaultRunner is a default implementation of the Runner interface.
@@ -71,25 +76,161 @@ func (r *defaultRunner) RegisterCheck(check Check) {
 }
 
 // RunChecks executes all registered checks.
-func (r *defaultRunner) RunChecks(ctx context.Context, cfg Config) ([]*Result, error) {
+func (r *defaultRunner) RunChecks(ctx context.Context, cfg Config) ([]*Result, *analyzer.AnalysisResult, error) {
 	results := make([]*Result, 0)
 
-	for _, check := range r.checks {
-		if cfg.ConsensusNode != ClientTypeAll.String() && check.ClientType() != ClientTypeCL {
-			continue
-		}
+	// Create analyzer based on which client type we're targeting.
+	var (
+		a      *analyzer.Analyzer
+		client string
+	)
 
-		if cfg.ExecutionNode != ClientTypeAll.String() && check.ClientType() != ClientTypeEL {
-			continue
-		}
-
-		result, err := check.Run(ctx, cfg)
-		if err != nil {
-			return nil, fmt.Errorf("failed to run check %s: %w", check.Name(), err)
-		}
-
-		results = append(results, result)
+	if cfg.ConsensusNode != ClientTypeAll.String() {
+		a = analyzer.NewAnalyzer(cfg.ConsensusNode, analyzer.ClientTypeCL)
+		client = cfg.ConsensusNode
+	} else if cfg.ExecutionNode != ClientTypeAll.String() {
+		a = analyzer.NewAnalyzer(cfg.ExecutionNode, analyzer.ClientTypeEL)
+		client = cfg.ExecutionNode
 	}
 
-	return results, nil
+	log.Printf("=== Running checks:\n  - %s\n  - %s", client, cfg.Network)
+
+	// Run all checks against ALL clients to gather complete data for analysis. This is important to
+	// allow us to identify root causes behind some of the client issues.
+	origConsensusNode := cfg.ConsensusNode
+	origExecutionNode := cfg.ExecutionNode
+	cfg.ConsensusNode = ClientTypeAll.String()
+	cfg.ExecutionNode = ClientTypeAll.String()
+
+	// First pass: gather all data for analysis.
+	allResults := make([]*Result, 0)
+
+	for _, check := range r.checks {
+		result, err := check.Run(ctx, cfg)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to run check %s: %w", check.Name(), err)
+		}
+
+		// Add all affected nodes to analyzer for complete analysis.
+		if result.Status == StatusFail {
+			for _, node := range result.AffectedNodes {
+				a.AddNodeStatus(node, false)
+			}
+		}
+
+		allResults = append(allResults, result)
+	}
+
+	// Run analysis with complete data.
+	analysisResult := a.Analyze()
+
+	// Second pass: filter results to only include target client data.
+	for _, result := range allResults {
+		if result.Status == StatusFail {
+			// Create a filtered copy of the result.
+			filteredResult := &Result{
+				Name:          result.Name,
+				Category:      result.Category,
+				Status:        result.Status,
+				Description:   result.Description,
+				Timestamp:     result.Timestamp,
+				Details:       make(map[string]interface{}),
+				AffectedNodes: make([]string, 0),
+			}
+
+			// Filter affected nodes..
+			for _, node := range result.AffectedNodes {
+				if strings.Contains(node, client) {
+					filteredResult.AffectedNodes = append(filteredResult.AffectedNodes, node)
+				}
+			}
+
+			// Only include result if it has affected nodes for our target client. We don't want
+			// to be including noisy about other clients in the notification.
+			if len(filteredResult.AffectedNodes) > 0 {
+				// Copy and filter details.
+				for k, v := range result.Details {
+					if k == "query" {
+						filteredResult.Details[k] = v
+
+						continue
+					}
+
+					// Filter node lists in details.
+					if str, ok := v.(string); ok {
+						filtered := make([]string, 0)
+
+						for _, line := range strings.Split(str, "\n") {
+							if strings.Contains(line, client) {
+								filtered = append(filtered, line)
+							}
+						}
+
+						if len(filtered) > 0 {
+							filteredResult.Details[k] = strings.Join(filtered, "\n")
+						}
+					}
+				}
+
+				results = append(results, filteredResult)
+			}
+		}
+	}
+
+	// Log analysis summary.
+	log.Printf("\n=== Analysis summary")
+
+	if len(analysisResult.RootCause) > 0 {
+		for _, rc := range analysisResult.RootCause {
+			log.Printf("  - %s identified as root cause", rc)
+		}
+	}
+
+	if len(analysisResult.UnexplainedIssues) > 0 {
+		for _, issue := range analysisResult.UnexplainedIssues {
+			log.Printf("  - %s (unexplained issue)", issue)
+		}
+	}
+
+	if len(analysisResult.RootCause) == 0 && len(analysisResult.UnexplainedIssues) == 0 {
+		log.Printf("  - No issues detected")
+	}
+
+	// Log our notification decision.
+	var (
+		hasUnexplainedIssues bool
+		isRootCause          bool
+	)
+
+	for _, rc := range analysisResult.RootCause {
+		if rc == client {
+			isRootCause = true
+
+			break
+		}
+	}
+
+	for _, issue := range analysisResult.UnexplainedIssues {
+		if strings.Contains(issue, client) {
+			hasUnexplainedIssues = true
+
+			break
+		}
+	}
+
+	log.Print("\n=== Notification decision")
+
+	if isRootCause {
+		log.Printf("  - NOTIFY: Client identified as root cause")
+	} else if hasUnexplainedIssues {
+		log.Printf("  - NOTIFY: Client has unexplained issues")
+	} else {
+		log.Printf("  - NO NOTIFICATION: No root cause or unexplained issues")
+	}
+
+	// Restore original config.
+	cfg.ConsensusNode = origConsensusNode
+	cfg.ExecutionNode = origExecutionNode
+
+	return results, analysisResult, nil
 }

--- a/pkg/checks/cl_peer_count.go
+++ b/pkg/checks/cl_peer_count.go
@@ -3,6 +3,7 @@ package checks
 import (
 	"context"
 	"fmt"
+	"log"
 	"strings"
 	"time"
 
@@ -44,6 +45,8 @@ func (c *CLPeerCountCheck) ClientType() ClientType {
 func (c *CLPeerCountCheck) Run(ctx context.Context, cfg Config) (*Result, error) {
 	query := fmt.Sprintf(queryCLPeerCount, cfg.Network, cfg.ConsensusNode, cfg.ExecutionNode)
 
+	log.Print("\n=== Running CL peer count check")
+
 	response, err := c.grafanaClient.Query(ctx, query)
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute query: %w", err)
@@ -56,13 +59,17 @@ func (c *CLPeerCountCheck) Run(ctx context.Context, cfg Config) (*Result, error)
 		for _, field := range frame.Schema.Fields {
 			if labels := field.Labels; labels != nil {
 				if labels["instance"] != "" {
-					lowPeerNodes = append(lowPeerNodes, strings.Replace(labels["instance"], labels["ingress_user"]+"-", "", -1))
+					nodeName := strings.Replace(labels["instance"], labels["ingress_user"]+"-", "", -1)
+					lowPeerNodes = append(lowPeerNodes, nodeName)
+					log.Printf("  - Low peer count: %s", nodeName)
 				}
 			}
 		}
 	}
 
 	if len(lowPeerNodes) == 0 {
+		log.Printf("  - All nodes have sufficient peers")
+
 		return &Result{
 			Name:        c.Name(),
 			Category:    c.Category(),
@@ -72,6 +79,7 @@ func (c *CLPeerCountCheck) Run(ctx context.Context, cfg Config) (*Result, error)
 			Details: map[string]interface{}{
 				"query": query,
 			},
+			AffectedNodes: []string{},
 		}, nil
 	}
 
@@ -85,5 +93,6 @@ func (c *CLPeerCountCheck) Run(ctx context.Context, cfg Config) (*Result, error)
 			"query":        query,
 			"lowPeerNodes": strings.Join(lowPeerNodes, "\n"),
 		},
+		AffectedNodes: lowPeerNodes,
 	}, nil
 }

--- a/pkg/checks/cl_sync.go
+++ b/pkg/checks/cl_sync.go
@@ -3,6 +3,7 @@ package checks
 import (
 	"context"
 	"fmt"
+	"log"
 	"strings"
 	"time"
 
@@ -46,6 +47,8 @@ func (c *CLSyncCheck) ClientType() ClientType {
 func (c *CLSyncCheck) Run(ctx context.Context, cfg Config) (*Result, error) {
 	query := fmt.Sprintf(queryCLSync, cfg.Network, cfg.ConsensusNode, cfg.ExecutionNode)
 
+	log.Print("\n=== Running CL sync check")
+
 	response, err := c.grafanaClient.Query(ctx, query)
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute query: %w", err)
@@ -58,13 +61,17 @@ func (c *CLSyncCheck) Run(ctx context.Context, cfg Config) (*Result, error) {
 		for _, field := range frame.Schema.Fields {
 			if labels := field.Labels; labels != nil {
 				if labels["instance"] != "" {
-					notSyncedNodes = append(notSyncedNodes, strings.Replace(labels["instance"], labels["ingress_user"]+"-", "", -1))
+					nodeName := strings.Replace(labels["instance"], labels["ingress_user"]+"-", "", -1)
+					notSyncedNodes = append(notSyncedNodes, nodeName)
+					log.Printf("  - Unsynced node: %s", nodeName)
 				}
 			}
 		}
 	}
 
 	if len(notSyncedNodes) == 0 {
+		log.Printf("  - All nodes are synced")
+
 		return &Result{
 			Name:        c.Name(),
 			Category:    c.Category(),
@@ -74,6 +81,7 @@ func (c *CLSyncCheck) Run(ctx context.Context, cfg Config) (*Result, error) {
 			Details: map[string]interface{}{
 				"query": query,
 			},
+			AffectedNodes: []string{},
 		}, nil
 	}
 
@@ -87,5 +95,6 @@ func (c *CLSyncCheck) Run(ctx context.Context, cfg Config) (*Result, error) {
 			"query":          query,
 			"notSyncedNodes": strings.Join(notSyncedNodes, "\n"),
 		},
+		AffectedNodes: notSyncedNodes,
 	}, nil
 }

--- a/pkg/checks/clients.go
+++ b/pkg/checks/clients.go
@@ -31,6 +31,7 @@ const (
 	CLTeku       = "teku"
 	CLGrandine   = "grandine"
 	ELNethermind = "nethermind"
+	ELNimbusel   = "nimbusel"
 	ELBesu       = "besu"
 	ELGeth       = "geth"
 	ELReth       = "reth"
@@ -41,7 +42,7 @@ const (
 // Buckets of known clients.
 var (
 	CLClients = []string{CLLighthouse, CLPrysm, CLLodestar, CLNimbus, CLTeku, CLGrandine}
-	ELClients = []string{ELNethermind, ELBesu, ELGeth, ELReth, ELErigon, ELEthereumJS}
+	ELClients = []string{ELNethermind, ELNimbusel, ELBesu, ELGeth, ELReth, ELErigon, ELEthereumJS}
 )
 
 // IsCLClient returns true if the client is a consensus client.

--- a/pkg/checks/el_sync.go
+++ b/pkg/checks/el_sync.go
@@ -3,6 +3,7 @@ package checks
 import (
 	"context"
 	"fmt"
+	"log"
 	"strings"
 	"time"
 
@@ -46,6 +47,8 @@ func (c *ELSyncCheck) ClientType() ClientType {
 func (c *ELSyncCheck) Run(ctx context.Context, cfg Config) (*Result, error) {
 	query := fmt.Sprintf(queryELSync, cfg.Network, cfg.ConsensusNode, cfg.ExecutionNode)
 
+	log.Print("\n=== Running EL sync check")
+
 	response, err := c.grafanaClient.Query(ctx, query)
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute query: %w", err)
@@ -58,13 +61,17 @@ func (c *ELSyncCheck) Run(ctx context.Context, cfg Config) (*Result, error) {
 		for _, field := range frame.Schema.Fields {
 			if labels := field.Labels; labels != nil {
 				if labels["instance"] != "" {
-					notSyncedNodes = append(notSyncedNodes, strings.Replace(labels["instance"], labels["network"]+"-", "", -1))
+					nodeName := strings.Replace(labels["instance"], labels["network"]+"-", "", -1)
+					notSyncedNodes = append(notSyncedNodes, nodeName)
+					log.Printf("  - Unsynced node: %s", nodeName)
 				}
 			}
 		}
 	}
 
 	if len(notSyncedNodes) == 0 {
+		log.Printf("  - All nodes are synced")
+
 		return &Result{
 			Name:        c.Name(),
 			Category:    c.Category(),
@@ -74,6 +81,7 @@ func (c *ELSyncCheck) Run(ctx context.Context, cfg Config) (*Result, error) {
 			Details: map[string]interface{}{
 				"query": query,
 			},
+			AffectedNodes: []string{},
 		}, nil
 	}
 
@@ -87,5 +95,6 @@ func (c *ELSyncCheck) Run(ctx context.Context, cfg Config) (*Result, error) {
 			"query":          query,
 			"notSyncedNodes": strings.Join(notSyncedNodes, "\n"),
 		},
+		AffectedNodes: notSyncedNodes,
 	}, nil
 }


### PR DESCRIPTION
Introduces a `pkg/analyzer` that does some root-cause analysis on check results, with the aim to reduce notification noise.

For example, if an EL client is failing to sync with multiple CL clients, it's likely that the EL client is the root cause. In this case, we should only notify the EL client's team, not all the CL client teams.

Key changes:
- New `pkg/analyzer` package that tracks node health and analyzes patterns
- Root cause detection for EL clients failing with multiple CL clients (its pretty crude atm, > 2)
- Filtering of notifications to only show relevant issues for the target client
- Added output/logging so we can follow the decisions taken.


<details>
<summary>
Example log output
</summary>

```
=== Running checks:
  - lighthouse
  - pectra-devnet-6

=== Running CL sync check
  - Unsynced node: grandine-erigon-1
  - Unsynced node: grandine-ethereumjs-1
  - Unsynced node: grandine-nimbusel-1
  - Unsynced node: lighthouse-ethereumjs-1
  - Unsynced node: lodestar-ethereumjs-1
  - Unsynced node: lodestar-nimbusel-1
  - Unsynced node: nimbus-ethereumjs-1
  - Unsynced node: nimbus-nimbusel-1
  - Unsynced node: prysm-ethereumjs-1
  - Unsynced node: prysm-nimbusel-1
  - Unsynced node: teku-nimbusel-1

=== Running CL head slot check
  - Not advancing head slot: grandine-erigon-1
  - Not advancing head slot: grandine-ethereumjs-1
  - Not advancing head slot: grandine-nimbusel-1
  - Not advancing head slot: lighthouse-ethereumjs-1
  - Not advancing head slot: lodestar-ethereumjs-1
  - Not advancing head slot: lodestar-nimbusel-1
  - Not advancing head slot: nimbus-ethereumjs-1
  - Not advancing head slot: nimbus-nimbusel-1
  - Not advancing head slot: prysm-ethereumjs-1
  - Not advancing head slot: prysm-nimbusel-1
  - Not advancing head slot: teku-ethereumjs-1
  - Not advancing head slot: teku-nimbusel-1

=== Running CL finalized epoch check
  - Not finalizing: grandine-erigon-1
  - Not finalizing: grandine-ethereumjs-1
  - Not finalizing: grandine-nimbusel-1
  - Not finalizing: lighthouse-ethereumjs-1
  - Not finalizing: lodestar-ethereumjs-1
  - Not finalizing: lodestar-nimbusel-1
  - Not finalizing: nimbus-ethereumjs-1
  - Not finalizing: nimbus-nimbusel-1
  - Not finalizing: prysm-ethereumjs-1
  - Not finalizing: prysm-nimbusel-1
  - Not finalizing: teku-ethereumjs-1
  - Not finalizing: teku-nimbusel-1

=== Running CL peer count check
  - All nodes have sufficient peers

=== Running EL sync check
  - All nodes are synced

=== Running EL peer count check
  - Low peer count: grandine-ethereumjs-1
  - Low peer count: grandine-reth-1
  - Low peer count: lighthouse-ethereumjs-1
  - Low peer count: lighthouse-reth-1
  - Low peer count: lighthouse-reth-2
  - Low peer count: lodestar-ethereumjs-1
  - Low peer count: lodestar-reth-1
  - Low peer count: nimbus-ethereumjs-1
  - Low peer count: nimbus-reth-1
  - Low peer count: prysm-ethereumjs-1
  - Low peer count: prysm-reth-1
  - Low peer count: prysm-reth-2
  - Low peer count: teku-ethereumjs-1
  - Low peer count: teku-reth-1
  - Low peer count: teku-reth-2

=== Running EL block height check
  - Not advancing block height: grandine-erigon-1
  - Not advancing block height: grandine-ethereumjs-1
  - Not advancing block height: grandine-nimbusel-1
  - Not advancing block height: lighthouse-ethereumjs-1
  - Not advancing block height: lighthouse-nimbusel-1
  - Not advancing block height: lodestar-ethereumjs-1
  - Not advancing block height: lodestar-nimbusel-1
  - Not advancing block height: nimbus-ethereumjs-1
  - Not advancing block height: nimbus-nimbusel-1
  - Not advancing block height: prysm-ethereumjs-1
  - Not advancing block height: prysm-nimbusel-1
  - Not advancing block height: teku-ethereumjs-1
  - Not advancing block height: teku-nimbusel-1

=== Analyzing lighthouse (CL)
  - nimbusel is failing with CL clients: grandine, teku, lodestar, nimbus, prysm, lighthouse
  - reth is failing with CL clients: grandine, teku, nimbus, lighthouse, lodestar, prysm
  - ethereumjs is failing with CL clients: teku, grandine, lodestar, nimbus, prysm, lighthouse
  - erigon is failing with CL clients: grandine

=== Analysis summary
  - nimbusel identified as root cause
  - reth identified as root cause
  - ethereumjs identified as root cause

=== Notification decision
  - NO NOTIFICATION: No root cause or unexplained issues
```
</details>