### PR TITLE
feat(notifier): ensure deterministic color is used for alerts based on network

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/mock v0.5.0
+	golang.org/x/text v0.3.3
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,7 @@ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/pkg/checks/clients.go
+++ b/pkg/checks/clients.go
@@ -1,5 +1,7 @@
 package checks
 
+import "strings"
+
 // ClientType represents the type of client.
 type ClientType string
 
@@ -65,4 +67,40 @@ func IsELClient(client string) bool {
 	}
 
 	return false
+}
+
+// GetClientLogo returns the Twitter profile image URL for a given client.
+func GetClientLogo(client string) string {
+	switch strings.ToLower(client) {
+	// Consensus Layer Clients
+	case CLLighthouse:
+		return "https://pbs.twimg.com/profile_images/1106229297151303681/EuqfU4v4_400x400.png"
+	case CLPrysm:
+		return "https://pbs.twimg.com/profile_images/1805984255861755905/PaPSwIzL_400x400.jpg"
+	case CLLodestar:
+		return "https://pbs.twimg.com/profile_images/1533709115712753665/O5PDykiV_400x400.jpg"
+	case CLNimbus:
+		return "https://pbs.twimg.com/profile_images/1721659785739960320/3XPpm8Or_400x400.jpg"
+	case CLTeku:
+		return "https://pbs.twimg.com/profile_images/1673661934036500480/Ee6NYB_K_400x400.jpg"
+	case CLGrandine:
+		return "https://pbs.twimg.com/profile_images/1409832041739345923/-ldZic7y_400x400.jpg"
+	// Execution Layer Clients
+	case ELNethermind:
+		return "https://pbs.twimg.com/profile_images/1806762018747072512/8XWySkUI_400x400.png"
+	case ELNimbusel:
+		return "https://pbs.twimg.com/profile_images/1721659785739960320/3XPpm8Or_400x400.jpg"
+	case ELBesu:
+		return "https://pbs.twimg.com/profile_images/1418537229123735552/XoFWio0T_400x400.jpg"
+	case ELGeth:
+		return "https://pbs.twimg.com/profile_images/1605238709451898881/Kl-bliNn_400x400.jpg"
+	case ELReth:
+		return "https://raw.githubusercontent.com/paradigmxyz/reth/refs/heads/main/assets/reth-docs.png"
+	case ELErigon:
+		return "https://pbs.twimg.com/profile_images/1420080204148576274/-4OFIs2x_400x400.jpg"
+	case ELEthereumJS:
+		return "https://pbs.twimg.com/profile_images/1330796558330322946/Y2YReI9m_400x400.png"
+	default:
+		return ""
+	}
 }

--- a/pkg/discord/notifier.go
+++ b/pkg/discord/notifier.go
@@ -2,9 +2,11 @@ package discord
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"sort"
 	"strings"
@@ -109,7 +111,7 @@ func (n *Notifier) SendResults(channelID string, network string, targetClient st
 	// Create and populate the main embed.
 	embed := &discordgo.MessageEmbed{
 		Title:     title,
-		Color:     0xff0000,
+		Color:     hashToColor(network),
 		Timestamp: time.Now().Format(time.RFC3339),
 		Fields:    make([]*discordgo.MessageEmbedField, 0),
 	}
@@ -449,4 +451,79 @@ func getCategoryEmoji(category checks.Category) string {
 	default:
 		return "📋"
 	}
+}
+
+// hashToColor generates a visually distinct, deterministic color int from a string.
+func hashToColor(s string) int {
+	hash := sha256.Sum256([]byte(s))
+
+	// Map hue to avoid green (90°-180°)
+	hue := remapHue(float64(hash[0]) / 255.0)
+	saturation := 0.75                                     // Fixed for vibrancy
+	lightness := 0.55 + (float64(hash[10]) / 255.0 * 0.15) // Ensures spread-out lightness
+
+	// Convert HSL to RGB
+	r, g, b := hslToRGB(hue, lightness, saturation)
+
+	// Convert to int in 0xRRGGBB format.
+	return (r << 16) | (g << 8) | b
+}
+
+// hslToRGB converts HSL to RGB (0-255 range for each color).
+func hslToRGB(h, l, s float64) (int, int, int) {
+	var r, g, b float64
+
+	if s == 0 {
+		r, g, b = l, l, l // Achromatic.
+	} else {
+		q := l * (1 + s)
+		if l >= 0.5 {
+			q = l + s - (l * s)
+		}
+
+		p := 2*l - q
+
+		r = hueToRGB(p, q, h+1.0/3.0)
+		g = hueToRGB(p, q, h)
+		b = hueToRGB(p, q, h-1.0/3.0)
+	}
+
+	return int(math.Round(r * 255)), int(math.Round(g * 255)), int(math.Round(b * 255))
+}
+
+// hueToRGB is a helper function for HSL to RGB conversion.
+func hueToRGB(p, q, t float64) float64 {
+	if t < 0 {
+		t += 1
+	}
+
+	if t > 1 {
+		t -= 1
+	}
+
+	if t < 1.0/6.0 {
+		return p + (q-p)*6*t
+	}
+
+	if t < 1.0/2.0 {
+		return q
+	}
+
+	if t < 2.0/3.0 {
+		return p + (q-p)*(2.0/3.0-t)*6
+	}
+
+	return p
+}
+
+// remapHue ensures the hue avoids green (90°-180°).
+func remapHue(h float64) float64 {
+	hueDegrees := h * 360.0
+
+	// If in green range (90-180°), shift to a non-green area.
+	if hueDegrees >= 90.0 && hueDegrees <= 180.0 {
+		hueDegrees = 180.0 + (hueDegrees - 90.0) // Shift it to the blue/purple spectrum.
+	}
+
+	return hueDegrees / 360.0 // Normalize back to 0-1 range.
 }

--- a/pkg/discord/notifier.go
+++ b/pkg/discord/notifier.go
@@ -15,6 +15,8 @@ import (
 	"github.com/bwmarrin/discordgo"
 	"github.com/ethpandaops/panda-pulse/pkg/analyzer"
 	"github.com/ethpandaops/panda-pulse/pkg/checks"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 // Notifier is a Discord notifier.
@@ -103,9 +105,9 @@ func (n *Notifier) SendResults(channelID string, network string, targetClient st
 		return nil
 	}
 
-	title := fmt.Sprintf("🐼 Pulse Check (%s)", network)
+	title := fmt.Sprintf("🐼 %s", network)
 	if targetClient != "" {
-		title = fmt.Sprintf("🐼 Pulse Check (%s - %s)", network, targetClient)
+		title = fmt.Sprintf("🐼 %s (%s)", cases.Title(language.English, cases.Compact).String(targetClient), network)
 	}
 
 	// Create and populate the main embed.

--- a/pkg/discord/notifier_test.go
+++ b/pkg/discord/notifier_test.go
@@ -1,0 +1,70 @@
+package discord
+
+import (
+	"testing"
+)
+
+func TestHashToColor(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantType int
+		// Each network should produce a consistent color.
+		wantConsistent bool
+		// Color shouldn't be green (no values between 0x009900 and 0x00FF00).
+		wantNotGreen bool
+	}{
+		{
+			name:           "devnet-1",
+			input:          "devnet-1",
+			wantType:       0,
+			wantConsistent: true,
+			wantNotGreen:   true,
+		},
+		{
+			name:           "empty string",
+			input:          "",
+			wantType:       0,
+			wantConsistent: true,
+			wantNotGreen:   true,
+		},
+		{
+			name:           "mainnet",
+			input:          "mainnet",
+			wantType:       0,
+			wantConsistent: true,
+			wantNotGreen:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test consistency.
+			if tt.wantConsistent {
+				color1 := hashToColor(tt.input)
+				color2 := hashToColor(tt.input)
+				if color1 != color2 {
+					t.Errorf("hashToColor not consistent for input %q: got %06x and %06x", tt.input, color1, color2)
+				}
+			}
+
+			// Test color format.
+			got := hashToColor(tt.input)
+			if got < 0 || got > 0xFFFFFF {
+				t.Errorf("hashToColor(%q) = %06x, want color between 000000 and FFFFFF", tt.input, got)
+			}
+
+			// Test not green.
+			if tt.wantNotGreen {
+				r := (got >> 16) & 0xFF
+				g := (got >> 8) & 0xFF
+				b := got & 0xFF
+
+				// Check if the color is predominantly green.
+				if g > r+50 && g > b+50 {
+					t.Errorf("hashToColor(%q) = %06x produced a green color (R:%02x, G:%02x, B:%02x)", tt.input, got, r, g, b)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Depending on network name, alert in a different color.
If we have >1 devnet in-play, this helps distinguish which alerts are for what.