### PR TITLE
feat(metrics): adds basic metrics for store, scheduler and queue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -64,6 +64,7 @@ require (
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20250224150550-a661cff19cfb // indirect
 	github.com/magiconair/properties v1.8.9 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect

--- a/pkg/discord/bot.go
+++ b/pkg/discord/bot.go
@@ -7,7 +7,6 @@ import (
 	"github.com/bwmarrin/discordgo"
 	cmdchecks "github.com/ethpandaops/panda-pulse/pkg/discord/cmd/checks"
 	"github.com/ethpandaops/panda-pulse/pkg/discord/cmd/common"
-	cmdmentions "github.com/ethpandaops/panda-pulse/pkg/discord/cmd/mentions"
 	"github.com/ethpandaops/panda-pulse/pkg/grafana"
 	"github.com/ethpandaops/panda-pulse/pkg/hive"
 	"github.com/ethpandaops/panda-pulse/pkg/scheduler"
@@ -41,8 +40,8 @@ type Bot interface {
 	GetRoleConfig() *common.RoleConfig
 }
 
-// discordBot represents the Discord bot implementation.
-type discordBot struct {
+// DiscordBot represents the Discord bot implementation.
+type DiscordBot struct {
 	log          *logrus.Logger
 	config       *Config
 	session      *discordgo.Session
@@ -72,7 +71,7 @@ func NewBot(
 		return nil, fmt.Errorf("failed to create discord session: %w", err)
 	}
 
-	bot := &discordBot{
+	bot := &DiscordBot{
 		log:          log,
 		config:       cfg,
 		session:      session,
@@ -85,18 +84,19 @@ func NewBot(
 		commands:     make([]common.Command, 0),
 	}
 
-	// Register command handlers.
-	bot.commands = append(bot.commands, cmdchecks.NewChecksCommand(log, bot))
-	bot.commands = append(bot.commands, cmdmentions.NewMentionsCommand(log, bot))
-
 	// Register event handlers.
 	session.AddHandler(bot.handleInteraction)
 
 	return bot, nil
 }
 
+// SetCommands sets the commands for the bot.
+func (b *DiscordBot) SetCommands(commands []common.Command) {
+	b.commands = commands
+}
+
 // Start starts the bot.
-func (b *discordBot) Start(ctx context.Context) error {
+func (b *DiscordBot) Start(ctx context.Context) error {
 	// Open connection with Discord.
 	if err := b.session.Open(); err != nil {
 		return fmt.Errorf("failed to open discord connection: %w", err)
@@ -122,7 +122,7 @@ func (b *discordBot) Start(ctx context.Context) error {
 }
 
 // Stop stops the bot.
-func (b *discordBot) Stop(ctx context.Context) error {
+func (b *DiscordBot) Stop(ctx context.Context) error {
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
@@ -132,42 +132,42 @@ func (b *discordBot) Stop(ctx context.Context) error {
 }
 
 // GetSession returns the Discord session.
-func (b *discordBot) GetSession() *discordgo.Session {
+func (b *DiscordBot) GetSession() *discordgo.Session {
 	return b.session
 }
 
 // GetScheduler returns the scheduler.
-func (b *discordBot) GetScheduler() *scheduler.Scheduler {
+func (b *DiscordBot) GetScheduler() *scheduler.Scheduler {
 	return b.scheduler
 }
 
 // GetMonitorRepo returns the monitor repository.
-func (b *discordBot) GetMonitorRepo() *store.MonitorRepo {
+func (b *DiscordBot) GetMonitorRepo() *store.MonitorRepo {
 	return b.monitorRepo
 }
 
 // GetChecksRepo returns the checks repository.
-func (b *discordBot) GetChecksRepo() *store.ChecksRepo {
+func (b *DiscordBot) GetChecksRepo() *store.ChecksRepo {
 	return b.checksRepo
 }
 
 // GetMentionsRepo returns the mentions repository.
-func (b *discordBot) GetMentionsRepo() *store.MentionsRepo {
+func (b *DiscordBot) GetMentionsRepo() *store.MentionsRepo {
 	return b.mentionsRepo
 }
 
 // GetGrafana returns the Grafana client.
-func (b *discordBot) GetGrafana() grafana.Client {
+func (b *DiscordBot) GetGrafana() grafana.Client {
 	return b.grafana
 }
 
 // GetHive returns the Hive client.
-func (b *discordBot) GetHive() hive.Hive {
+func (b *DiscordBot) GetHive() hive.Hive {
 	return b.hive
 }
 
 // handleInteraction handles interactions from the Discord client.
-func (b *discordBot) handleInteraction(s *discordgo.Session, i *discordgo.InteractionCreate) {
+func (b *DiscordBot) handleInteraction(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	if i.Type != discordgo.InteractionApplicationCommand {
 		return
 	}
@@ -197,7 +197,7 @@ func (b *discordBot) handleInteraction(s *discordgo.Session, i *discordgo.Intera
 }
 
 // scheduleExistingAlerts schedules existing monitor alerts.
-func (b *discordBot) scheduleExistingAlerts() error {
+func (b *DiscordBot) scheduleExistingAlerts() error {
 	alerts, err := b.monitorRepo.List(context.Background())
 	if err != nil {
 		return fmt.Errorf("failed to list alerts: %w", err)
@@ -211,7 +211,7 @@ func (b *discordBot) scheduleExistingAlerts() error {
 		return nil
 	}
 
-	checksCmd := b.getChecksCmd()
+	checksCmd := b.GetChecksCmd()
 	if checksCmd == nil {
 		return fmt.Errorf("checks command not found")
 	}
@@ -255,8 +255,8 @@ func (b *discordBot) scheduleExistingAlerts() error {
 	return nil
 }
 
-// getChecksCmd returns the checks command.
-func (b *discordBot) getChecksCmd() *cmdchecks.ChecksCommand {
+// GetChecksCmd returns the checks command.
+func (b *DiscordBot) GetChecksCmd() *cmdchecks.ChecksCommand {
 	for _, cmd := range b.commands {
 		if c, ok := cmd.(*cmdchecks.ChecksCommand); ok {
 			return c
@@ -267,6 +267,6 @@ func (b *discordBot) getChecksCmd() *cmdchecks.ChecksCommand {
 }
 
 // GetRoleConfig returns the role configuration.
-func (b *discordBot) GetRoleConfig() *common.RoleConfig {
+func (b *DiscordBot) GetRoleConfig() *common.RoleConfig {
 	return b.config.AsRoleConfig()
 }

--- a/pkg/discord/bot.go
+++ b/pkg/discord/bot.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethpandaops/panda-pulse/pkg/discord/cmd/common"
 	"github.com/ethpandaops/panda-pulse/pkg/grafana"
 	"github.com/ethpandaops/panda-pulse/pkg/hive"
+	"github.com/ethpandaops/panda-pulse/pkg/queue"
 	"github.com/ethpandaops/panda-pulse/pkg/scheduler"
 	"github.com/ethpandaops/panda-pulse/pkg/store"
 	"github.com/sirupsen/logrus"
@@ -38,6 +39,8 @@ type Bot interface {
 	BotCore
 	BotServices
 	GetRoleConfig() *common.RoleConfig
+	SetCommands(commands []common.Command)
+	GetQueues() []queue.Queuer
 }
 
 // DiscordBot represents the Discord bot implementation.
@@ -269,4 +272,18 @@ func (b *DiscordBot) GetChecksCmd() *cmdchecks.ChecksCommand {
 // GetRoleConfig returns the role configuration.
 func (b *DiscordBot) GetRoleConfig() *common.RoleConfig {
 	return b.config.AsRoleConfig()
+}
+
+// GetQueues returns all queues managed by the bot.
+func (b *DiscordBot) GetQueues() []queue.Queuer {
+	var queues []queue.Queuer
+
+	// Add checks queue if available
+	if checksCmd := b.GetChecksCmd(); checksCmd != nil {
+		if q := checksCmd.Queue(); q != nil {
+			queues = append(queues, q)
+		}
+	}
+
+	return queues
 }

--- a/pkg/discord/cmd/checks/command.go
+++ b/pkg/discord/cmd/checks/command.go
@@ -30,16 +30,23 @@ const (
 type ChecksCommand struct {
 	log   *logrus.Logger
 	bot   common.BotContext
-	queue *queue.Queue
+	queue *queue.AlertQueue
 }
 
-// NewChecksCommand creates a new ChecksCommand.
-func NewChecksCommand(log *logrus.Logger, bot common.BotContext, queue *queue.Queue) *ChecksCommand {
-	return &ChecksCommand{
-		log:   log,
-		bot:   bot,
-		queue: queue,
+// NewChecksCommand creates a new checks command.
+func NewChecksCommand(log *logrus.Logger, bot common.BotContext) *ChecksCommand {
+	cmd := &ChecksCommand{
+		log: log,
+		bot: bot,
 	}
+
+	cmd.queue = queue.NewAlertQueue(
+		log,
+		cmd.RunChecks,
+		queue.NewMetrics("panda_pulse"),
+	)
+
+	return cmd
 }
 
 // Name returns the name of the command.
@@ -47,8 +54,8 @@ func (c *ChecksCommand) Name() string {
 	return "checks"
 }
 
-// Queue returns the queue associated with the ChecksCommand.
-func (c *ChecksCommand) Queue() *queue.Queue {
+// Queue returns the queue instance.
+func (c *ChecksCommand) Queue() *queue.AlertQueue {
 	return c.queue
 }
 

--- a/pkg/discord/cmd/checks/command.go
+++ b/pkg/discord/cmd/checks/command.go
@@ -34,17 +34,12 @@ type ChecksCommand struct {
 }
 
 // NewChecksCommand creates a new ChecksCommand.
-func NewChecksCommand(log *logrus.Logger, bot common.BotContext) *ChecksCommand {
-	cmd := &ChecksCommand{
-		log: log,
-		bot: bot,
+func NewChecksCommand(log *logrus.Logger, bot common.BotContext, queue *queue.Queue) *ChecksCommand {
+	return &ChecksCommand{
+		log:   log,
+		bot:   bot,
+		queue: queue,
 	}
-
-	// Create queue with RunChecks as the worker
-	cmd.queue = queue.NewQueue(log, cmd.RunChecks)
-	cmd.queue.Start(context.Background())
-
-	return cmd
 }
 
 // Name returns the name of the command.

--- a/pkg/discord/mock/bot.mock.go
+++ b/pkg/discord/mock/bot.mock.go
@@ -17,6 +17,7 @@ import (
 	common "github.com/ethpandaops/panda-pulse/pkg/discord/cmd/common"
 	grafana "github.com/ethpandaops/panda-pulse/pkg/grafana"
 	hive "github.com/ethpandaops/panda-pulse/pkg/hive"
+	queue "github.com/ethpandaops/panda-pulse/pkg/queue"
 	scheduler "github.com/ethpandaops/panda-pulse/pkg/scheduler"
 	store "github.com/ethpandaops/panda-pulse/pkg/store"
 	gomock "go.uber.org/mock/gomock"
@@ -116,6 +117,20 @@ func (mr *MockBotMockRecorder) GetMonitorRepo() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMonitorRepo", reflect.TypeOf((*MockBot)(nil).GetMonitorRepo))
 }
 
+// GetQueues mocks base method.
+func (m *MockBot) GetQueues() []queue.Queuer {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetQueues")
+	ret0, _ := ret[0].([]queue.Queuer)
+	return ret0
+}
+
+// GetQueues indicates an expected call of GetQueues.
+func (mr *MockBotMockRecorder) GetQueues() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetQueues", reflect.TypeOf((*MockBot)(nil).GetQueues))
+}
+
 // GetRoleConfig mocks base method.
 func (m *MockBot) GetRoleConfig() *common.RoleConfig {
 	m.ctrl.T.Helper()
@@ -156,6 +171,18 @@ func (m *MockBot) GetSession() *discordgo.Session {
 func (mr *MockBotMockRecorder) GetSession() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSession", reflect.TypeOf((*MockBot)(nil).GetSession))
+}
+
+// SetCommands mocks base method.
+func (m *MockBot) SetCommands(commands []common.Command) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetCommands", commands)
+}
+
+// SetCommands indicates an expected call of SetCommands.
+func (mr *MockBotMockRecorder) SetCommands(commands any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCommands", reflect.TypeOf((*MockBot)(nil).SetCommands), commands)
 }
 
 // Start mocks base method.

--- a/pkg/queue/metrics.go
+++ b/pkg/queue/metrics.go
@@ -1,0 +1,70 @@
+package queue
+
+import "github.com/prometheus/client_golang/prometheus"
+
+type Metrics struct {
+	queuedTotal    *prometheus.CounterVec
+	processedTotal *prometheus.CounterVec
+	failuresTotal  *prometheus.CounterVec
+	queueLength    prometheus.Gauge
+	processingTime *prometheus.HistogramVec
+	skipsDueToLock *prometheus.CounterVec
+}
+
+func NewMetrics(namespace string) *Metrics {
+	m := &Metrics{
+		queuedTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: "queue",
+			Name:      "checks_queued_total",
+			Help:      "Total number of checks queued",
+		}, []string{"network", "client"}),
+
+		processedTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: "queue",
+			Name:      "checks_processed_total",
+			Help:      "Total number of checks processed",
+		}, []string{"network", "client", "status"}),
+
+		failuresTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: "queue",
+			Name:      "checks_failures_total",
+			Help:      "Total number of check failures",
+		}, []string{"network", "client", "error_type"}),
+
+		queueLength: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: "queue",
+			Name:      "length_current",
+			Help:      "Current number of checks in queue",
+		}),
+
+		processingTime: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: "queue",
+			Name:      "check_processing_duration_seconds",
+			Help:      "Time taken to process checks",
+			Buckets:   []float64{1, 5, 10, 30, 60, 120, 300},
+		}, []string{"network", "client"}),
+
+		skipsDueToLock: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: "queue",
+			Name:      "checks_skipped_total",
+			Help:      "Number of checks skipped due to lock",
+		}, []string{"network", "client"}),
+	}
+
+	prometheus.MustRegister(
+		m.queuedTotal,
+		m.processedTotal,
+		m.failuresTotal,
+		m.queueLength,
+		m.processingTime,
+		m.skipsDueToLock,
+	)
+
+	return m
+}

--- a/pkg/queue/metrics_test.go
+++ b/pkg/queue/metrics_test.go
@@ -1,0 +1,85 @@
+package queue
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMetrics(t *testing.T) {
+	t.Run("metrics are registered successfully", func(t *testing.T) {
+		prometheus.DefaultRegisterer = prometheus.NewRegistry()
+		m := NewMetrics("test")
+		assert.NotNil(t, m)
+
+		expected := `
+# HELP test_queue_length_current Current number of checks in queue
+# TYPE test_queue_length_current gauge
+test_queue_length_current 0
+`
+		assert.NoError(t, testutil.CollectAndCompare(m.queueLength, strings.NewReader(expected)))
+	})
+
+	t.Run("counter metrics increment correctly", func(t *testing.T) {
+		prometheus.DefaultRegisterer = prometheus.NewRegistry()
+		m := NewMetrics("test")
+
+		// Test queuedTotal
+		m.queuedTotal.WithLabelValues("testnet", "client1").Inc()
+		assert.Equal(t, float64(1), testutil.ToFloat64(m.queuedTotal.WithLabelValues("testnet", "client1")))
+
+		// Test processedTotal
+		m.processedTotal.WithLabelValues("testnet", "client1", "success").Inc()
+		assert.Equal(t, float64(1), testutil.ToFloat64(m.processedTotal.WithLabelValues("testnet", "client1", "success")))
+
+		// Test failuresTotal
+		m.failuresTotal.WithLabelValues("testnet", "client1", "worker_error").Inc()
+		assert.Equal(t, float64(1), testutil.ToFloat64(m.failuresTotal.WithLabelValues("testnet", "client1", "worker_error")))
+
+		// Test skipsDueToLock
+		m.skipsDueToLock.WithLabelValues("testnet", "client1").Inc()
+		assert.Equal(t, float64(1), testutil.ToFloat64(m.skipsDueToLock.WithLabelValues("testnet", "client1")))
+	})
+
+	t.Run("gauge metrics update correctly", func(t *testing.T) {
+		prometheus.DefaultRegisterer = prometheus.NewRegistry()
+		m := NewMetrics("test")
+
+		// Test queueLength
+		m.queueLength.Set(5)
+		assert.Equal(t, float64(5), testutil.ToFloat64(m.queueLength))
+
+		m.queueLength.Dec()
+		assert.Equal(t, float64(4), testutil.ToFloat64(m.queueLength))
+
+		m.queueLength.Inc()
+		assert.Equal(t, float64(5), testutil.ToFloat64(m.queueLength))
+	})
+
+	t.Run("histogram metrics record correctly", func(t *testing.T) {
+		prometheus.DefaultRegisterer = prometheus.NewRegistry()
+		m := NewMetrics("test")
+
+		m.processingTime.WithLabelValues("testnet", "client1").Observe(1.5)
+		m.processingTime.WithLabelValues("testnet", "client1").Observe(2.5)
+
+		expected := `
+# HELP test_queue_check_processing_duration_seconds Time taken to process checks
+# TYPE test_queue_check_processing_duration_seconds histogram
+test_queue_check_processing_duration_seconds_bucket{client="client1",network="testnet",le="1"} 0
+test_queue_check_processing_duration_seconds_bucket{client="client1",network="testnet",le="5"} 2
+test_queue_check_processing_duration_seconds_bucket{client="client1",network="testnet",le="10"} 2
+test_queue_check_processing_duration_seconds_bucket{client="client1",network="testnet",le="30"} 2
+test_queue_check_processing_duration_seconds_bucket{client="client1",network="testnet",le="60"} 2
+test_queue_check_processing_duration_seconds_bucket{client="client1",network="testnet",le="120"} 2
+test_queue_check_processing_duration_seconds_bucket{client="client1",network="testnet",le="300"} 2
+test_queue_check_processing_duration_seconds_bucket{client="client1",network="testnet",le="+Inf"} 2
+test_queue_check_processing_duration_seconds_sum{client="client1",network="testnet"} 4
+test_queue_check_processing_duration_seconds_count{client="client1",network="testnet"} 2
+`
+		assert.NoError(t, testutil.CollectAndCompare(m.processingTime, strings.NewReader(expected)))
+	})
+}

--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -19,13 +19,18 @@ type Queue struct {
 }
 
 // NewQueue creates a new check queue.
-func NewQueue(log *logrus.Logger, worker func(context.Context, *store.MonitorAlert) (bool, error)) *Queue {
+func NewQueue(log *logrus.Logger, worker func(context.Context, *store.MonitorAlert) (bool, error), metrics *Metrics) *Queue {
 	return &Queue{
 		log:     log,
 		queue:   make(chan *store.MonitorAlert, 100),
 		worker:  worker,
-		metrics: NewMetrics("panda_pulse"),
+		metrics: metrics,
 	}
+}
+
+// SetWorker sets the worker function for processing alerts.
+func (q *Queue) SetWorker(worker func(context.Context, *store.MonitorAlert) (bool, error)) {
+	q.worker = worker
 }
 
 func (q *Queue) Start(ctx context.Context) {

--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -9,70 +9,94 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// Queue is a queue of alerts to be processed.
-type Queue struct {
+// Queuer defines the interface for queue operations.
+type Queuer interface {
+	Start(ctx context.Context)
+	Stop(ctx context.Context)
+}
+
+// AlertQueue is a concrete queue type for MonitorAlerts.
+type AlertQueue struct {
+	*Queue[*store.MonitorAlert]
+}
+
+// NewAlertQueue creates a new alert queue.
+func NewAlertQueue(log *logrus.Logger, worker func(context.Context, *store.MonitorAlert) (bool, error), metrics *Metrics) *AlertQueue {
+	return &AlertQueue{
+		Queue: NewQueue[*store.MonitorAlert](log, worker, metrics),
+	}
+}
+
+// Queue is a generic queue for processing items.
+type Queue[T any] struct {
 	log        *logrus.Logger
-	queue      chan *store.MonitorAlert
+	queue      chan T
 	processing sync.Map
-	worker     func(context.Context, *store.MonitorAlert) (bool, error)
+	worker     func(context.Context, T) (bool, error)
 	metrics    *Metrics
 }
 
-// NewQueue creates a new check queue.
-func NewQueue(log *logrus.Logger, worker func(context.Context, *store.MonitorAlert) (bool, error), metrics *Metrics) *Queue {
-	return &Queue{
+// NewQueue creates a new queue.
+func NewQueue[T any](log *logrus.Logger, worker func(context.Context, T) (bool, error), metrics *Metrics) *Queue[T] {
+	return &Queue[T]{
 		log:     log,
-		queue:   make(chan *store.MonitorAlert, 100),
+		queue:   make(chan T, 100),
 		worker:  worker,
 		metrics: metrics,
 	}
 }
 
-// SetWorker sets the worker function for processing alerts.
-func (q *Queue) SetWorker(worker func(context.Context, *store.MonitorAlert) (bool, error)) {
+// SetWorker sets the worker function for processing items.
+func (q *Queue[T]) SetWorker(worker func(context.Context, T) (bool, error)) {
 	q.worker = worker
 }
 
-func (q *Queue) Start(ctx context.Context) {
+func (q *Queue[T]) Start(ctx context.Context) {
 	go q.processQueue(ctx)
 }
 
-func (q *Queue) Enqueue(alert *store.MonitorAlert) {
-	if _, exists := q.processing.LoadOrStore(q.getAlertKey(alert), true); exists {
-		q.metrics.skipsDueToLock.WithLabelValues(alert.Network, alert.Client).Inc()
+// Stop stops the queue processor.
+func (q *Queue[T]) Stop(ctx context.Context) {
+	// The queue processor will stop when the context is cancelled.
+	q.metrics.queueLength.Set(0)
+}
+
+func (q *Queue[T]) Enqueue(item T) {
+	if _, exists := q.processing.LoadOrStore(q.getItemKey(item), true); exists {
+		q.metrics.skipsDueToLock.WithLabelValues(q.getItemNetwork(item), q.getItemClient(item)).Inc()
 		q.log.WithFields(logrus.Fields{
-			"network": alert.Network,
-			"client":  alert.Client,
-		}).Debug("Check already in progress, skipping")
+			"network": q.getItemNetwork(item),
+			"client":  q.getItemClient(item),
+		}).Debug("Item already in progress, skipping")
 
 		return
 	}
 
-	q.metrics.queuedTotal.WithLabelValues(alert.Network, alert.Client).Inc()
+	q.metrics.queuedTotal.WithLabelValues(q.getItemNetwork(item), q.getItemClient(item)).Inc()
 	q.metrics.queueLength.Inc()
-	q.queue <- alert
+	q.queue <- item
 }
 
-// processQueue processes the queue of alerts.
-func (q *Queue) processQueue(ctx context.Context) {
+// processQueue processes the queue of items.
+func (q *Queue[T]) processQueue(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case alert := <-q.queue:
+		case item := <-q.queue:
 			start := time.Now()
-			key := q.getAlertKey(alert)
+			key := q.getItemKey(item)
 
 			q.metrics.queueLength.Dec()
 
-			success, err := q.worker(ctx, alert)
+			success, err := q.worker(ctx, item)
 			duration := time.Since(start).Seconds()
 
-			q.metrics.processingTime.WithLabelValues(alert.Network, alert.Client).Observe(duration)
+			q.metrics.processingTime.WithLabelValues(q.getItemNetwork(item), q.getItemClient(item)).Observe(duration)
 
 			if err != nil {
-				q.metrics.failuresTotal.WithLabelValues(alert.Network, alert.Client, "worker_error").Inc()
-				q.log.WithError(err).Error("Failed to process check")
+				q.metrics.failuresTotal.WithLabelValues(q.getItemNetwork(item), q.getItemClient(item), "worker_error").Inc()
+				q.log.WithError(err).Error("Failed to process item")
 			}
 
 			status := "success"
@@ -80,7 +104,7 @@ func (q *Queue) processQueue(ctx context.Context) {
 				status = "failed"
 			}
 
-			q.metrics.processedTotal.WithLabelValues(alert.Network, alert.Client, status).Inc()
+			q.metrics.processedTotal.WithLabelValues(q.getItemNetwork(item), q.getItemClient(item), status).Inc()
 
 			q.processing.Delete(key)
 
@@ -89,7 +113,25 @@ func (q *Queue) processQueue(ctx context.Context) {
 	}
 }
 
-// getAlertKey returns a unique key for the alert.
-func (q *Queue) getAlertKey(alert *store.MonitorAlert) string {
-	return alert.Network + "-" + alert.Client
+// getItemKey returns a unique key for the item.
+func (q *Queue[T]) getItemKey(item T) string {
+	return q.getItemNetwork(item) + "-" + q.getItemClient(item)
+}
+
+// getItemNetwork returns the network for the item.
+func (q *Queue[T]) getItemNetwork(item T) string {
+	if alert, ok := any(item).(*store.MonitorAlert); ok {
+		return alert.Network
+	}
+
+	return "unknown"
+}
+
+// getItemClient returns the client for the item.
+func (q *Queue[T]) getItemClient(item T) string {
+	if alert, ok := any(item).(*store.MonitorAlert); ok {
+		return alert.Client
+	}
+
+	return "unknown"
 }

--- a/pkg/queue/queue_test.go
+++ b/pkg/queue/queue_test.go
@@ -7,12 +7,22 @@ import (
 	"time"
 
 	"github.com/ethpandaops/panda-pulse/pkg/store"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
+func setupTest(t *testing.T) {
+	t.Helper()
+
+	prometheus.DefaultRegisterer = prometheus.NewRegistry()
+}
+
 func TestQueue(t *testing.T) {
+	setupTest(t)
+
 	t.Run("processes items in order", func(t *testing.T) {
+		setupTest(t)
 		var processed int32
 		worker := func(ctx context.Context, alert *store.MonitorAlert) (bool, error) {
 			atomic.AddInt32(&processed, 1)
@@ -41,6 +51,7 @@ func TestQueue(t *testing.T) {
 	})
 
 	t.Run("prevents duplicate processing", func(t *testing.T) {
+		setupTest(t)
 		var processed int32
 		worker := func(ctx context.Context, alert *store.MonitorAlert) (bool, error) {
 			atomic.AddInt32(&processed, 1)
@@ -62,6 +73,7 @@ func TestQueue(t *testing.T) {
 	})
 
 	t.Run("respects context cancellation", func(t *testing.T) {
+		setupTest(t)
 		var processed int32
 
 		worker := func(ctx context.Context, alert *store.MonitorAlert) (bool, error) {
@@ -85,6 +97,7 @@ func TestQueue(t *testing.T) {
 }
 
 func TestGetAlertKey(t *testing.T) {
+	setupTest(t)
 	q := NewQueue(logrus.New(), nil)
 	alert := &store.MonitorAlert{
 		Network: "testnet",

--- a/pkg/queue/queue_test.go
+++ b/pkg/queue/queue_test.go
@@ -30,7 +30,7 @@ func TestQueue(t *testing.T) {
 			return true, nil
 		}
 
-		q := NewQueue(logrus.New(), worker)
+		q := NewQueue(logrus.New(), worker, NewMetrics("test"))
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		q.Start(ctx)
@@ -59,7 +59,7 @@ func TestQueue(t *testing.T) {
 			return true, nil
 		}
 
-		q := NewQueue(logrus.New(), worker)
+		q := NewQueue(logrus.New(), worker, NewMetrics("test"))
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		q.Start(ctx)
@@ -82,7 +82,7 @@ func TestQueue(t *testing.T) {
 			return true, nil
 		}
 
-		q := NewQueue(logrus.New(), worker)
+		q := NewQueue(logrus.New(), worker, NewMetrics("test"))
 		ctx, cancel := context.WithCancel(context.Background())
 		q.Start(ctx)
 
@@ -98,7 +98,7 @@ func TestQueue(t *testing.T) {
 
 func TestGetAlertKey(t *testing.T) {
 	setupTest(t)
-	q := NewQueue(logrus.New(), nil)
+	q := NewQueue(logrus.New(), nil, NewMetrics("test"))
 	alert := &store.MonitorAlert{
 		Network: "testnet",
 		Client:  "client1",

--- a/pkg/queue/queue_test.go
+++ b/pkg/queue/queue_test.go
@@ -30,7 +30,7 @@ func TestQueue(t *testing.T) {
 			return true, nil
 		}
 
-		q := NewQueue(logrus.New(), worker, NewMetrics("test"))
+		q := NewQueue[*store.MonitorAlert](logrus.New(), worker, NewMetrics("test"))
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		q.Start(ctx)
@@ -59,7 +59,7 @@ func TestQueue(t *testing.T) {
 			return true, nil
 		}
 
-		q := NewQueue(logrus.New(), worker, NewMetrics("test"))
+		q := NewQueue[*store.MonitorAlert](logrus.New(), worker, NewMetrics("test"))
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		q.Start(ctx)
@@ -82,7 +82,7 @@ func TestQueue(t *testing.T) {
 			return true, nil
 		}
 
-		q := NewQueue(logrus.New(), worker, NewMetrics("test"))
+		q := NewQueue[*store.MonitorAlert](logrus.New(), worker, NewMetrics("test"))
 		ctx, cancel := context.WithCancel(context.Background())
 		q.Start(ctx)
 
@@ -98,10 +98,10 @@ func TestQueue(t *testing.T) {
 
 func TestGetAlertKey(t *testing.T) {
 	setupTest(t)
-	q := NewQueue(logrus.New(), nil, NewMetrics("test"))
+	q := NewQueue[*store.MonitorAlert](logrus.New(), nil, NewMetrics("test"))
 	alert := &store.MonitorAlert{
 		Network: "testnet",
 		Client:  "client1",
 	}
-	assert.Equal(t, "testnet-client1", q.getAlertKey(alert))
+	assert.Equal(t, "testnet-client1", q.getItemKey(alert))
 }

--- a/pkg/scheduler/metrics.go
+++ b/pkg/scheduler/metrics.go
@@ -1,0 +1,70 @@
+package scheduler
+
+import "github.com/prometheus/client_golang/prometheus"
+
+type Metrics struct {
+	jobsTotal       *prometheus.CounterVec
+	jobExecutions   *prometheus.CounterVec
+	jobFailures     *prometheus.CounterVec
+	activeJobs      prometheus.Gauge
+	executionTime   *prometheus.HistogramVec
+	lastExecutionTS *prometheus.GaugeVec
+}
+
+func NewMetrics(namespace string) *Metrics {
+	m := &Metrics{
+		jobsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: "scheduler",
+			Name:      "jobs_total",
+			Help:      "Total number of jobs registered",
+		}, []string{"schedule"}),
+
+		jobExecutions: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: "scheduler",
+			Name:      "job_executions_total",
+			Help:      "Total number of job executions",
+		}, []string{"name", "schedule"}),
+
+		jobFailures: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: "scheduler",
+			Name:      "job_failures_total",
+			Help:      "Total number of job failures",
+		}, []string{"name", "schedule"}),
+
+		activeJobs: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: "scheduler",
+			Name:      "active_jobs",
+			Help:      "Current number of active jobs",
+		}),
+
+		executionTime: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: "scheduler",
+			Name:      "job_execution_duration_seconds",
+			Help:      "Time taken to execute jobs",
+			Buckets:   []float64{0.1, 0.5, 1, 2, 5, 10, 30},
+		}, []string{"name"}),
+
+		lastExecutionTS: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: "scheduler",
+			Name:      "job_last_execution_timestamp",
+			Help:      "Timestamp of last job execution",
+		}, []string{"name", "schedule"}),
+	}
+
+	prometheus.MustRegister(
+		m.jobsTotal,
+		m.jobExecutions,
+		m.jobFailures,
+		m.activeJobs,
+		m.executionTime,
+		m.lastExecutionTS,
+	)
+
+	return m
+}

--- a/pkg/scheduler/metrics_test.go
+++ b/pkg/scheduler/metrics_test.go
@@ -1,0 +1,94 @@
+package scheduler
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMetrics(t *testing.T) {
+	// Reset the default registry to avoid conflicts
+	prometheus.DefaultRegisterer = prometheus.NewRegistry()
+
+	t.Run("metrics are registered successfully", func(t *testing.T) {
+		prometheus.DefaultRegisterer = prometheus.NewRegistry()
+		m := NewMetrics("test")
+		assert.NotNil(t, m)
+
+		expected := `
+# HELP test_scheduler_active_jobs Current number of active jobs
+# TYPE test_scheduler_active_jobs gauge
+test_scheduler_active_jobs 0
+`
+		assert.NoError(t, testutil.CollectAndCompare(m.activeJobs, strings.NewReader(expected)))
+	})
+
+	t.Run("counter metrics increment correctly", func(t *testing.T) {
+		prometheus.DefaultRegisterer = prometheus.NewRegistry()
+		m := NewMetrics("test")
+
+		// Test jobsTotal
+		m.jobsTotal.WithLabelValues("* * * * *").Inc()
+		assert.Equal(t, float64(1), testutil.ToFloat64(m.jobsTotal.WithLabelValues("* * * * *")))
+
+		// Test jobExecutions
+		m.jobExecutions.WithLabelValues("test_job", "* * * * *").Inc()
+		assert.Equal(t, float64(1), testutil.ToFloat64(m.jobExecutions.WithLabelValues("test_job", "* * * * *")))
+
+		// Test jobFailures
+		m.jobFailures.WithLabelValues("test_job", "* * * * *").Inc()
+		assert.Equal(t, float64(1), testutil.ToFloat64(m.jobFailures.WithLabelValues("test_job", "* * * * *")))
+	})
+
+	t.Run("gauge metrics update correctly", func(t *testing.T) {
+		prometheus.DefaultRegisterer = prometheus.NewRegistry()
+		m := NewMetrics("test")
+
+		// Test activeJobs
+		m.activeJobs.Set(3)
+		assert.Equal(t, float64(3), testutil.ToFloat64(m.activeJobs))
+
+		m.activeJobs.Dec()
+		assert.Equal(t, float64(2), testutil.ToFloat64(m.activeJobs))
+
+		m.activeJobs.Inc()
+		assert.Equal(t, float64(3), testutil.ToFloat64(m.activeJobs))
+	})
+
+	t.Run("histogram metrics record correctly", func(t *testing.T) {
+		prometheus.DefaultRegisterer = prometheus.NewRegistry()
+		m := NewMetrics("test")
+
+		m.executionTime.WithLabelValues("test_job").Observe(0.5)
+		m.executionTime.WithLabelValues("test_job").Observe(1.5)
+
+		expected := `
+# HELP test_scheduler_job_execution_duration_seconds Time taken to execute jobs
+# TYPE test_scheduler_job_execution_duration_seconds histogram
+test_scheduler_job_execution_duration_seconds_bucket{name="test_job",le="0.1"} 0
+test_scheduler_job_execution_duration_seconds_bucket{name="test_job",le="0.5"} 1
+test_scheduler_job_execution_duration_seconds_bucket{name="test_job",le="1"} 1
+test_scheduler_job_execution_duration_seconds_bucket{name="test_job",le="2"} 2
+test_scheduler_job_execution_duration_seconds_bucket{name="test_job",le="5"} 2
+test_scheduler_job_execution_duration_seconds_bucket{name="test_job",le="10"} 2
+test_scheduler_job_execution_duration_seconds_bucket{name="test_job",le="30"} 2
+test_scheduler_job_execution_duration_seconds_bucket{name="test_job",le="+Inf"} 2
+test_scheduler_job_execution_duration_seconds_sum{name="test_job"} 2
+test_scheduler_job_execution_duration_seconds_count{name="test_job"} 2
+`
+		assert.NoError(t, testutil.CollectAndCompare(m.executionTime, strings.NewReader(expected)))
+	})
+
+	t.Run("timestamp metrics update correctly", func(t *testing.T) {
+		prometheus.DefaultRegisterer = prometheus.NewRegistry()
+		m := NewMetrics("test")
+
+		// Test lastExecutionTS
+		timestamp := float64(1234567890)
+		m.lastExecutionTS.WithLabelValues("test_job", "* * * * *").Set(timestamp)
+		assert.Equal(t, timestamp, testutil.ToFloat64(m.lastExecutionTS.WithLabelValues("test_job", "* * * * *")))
+	})
+}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -24,12 +24,12 @@ type Scheduler struct {
 	metrics *Metrics
 }
 
-func NewScheduler(log *logrus.Logger) *Scheduler {
+func NewScheduler(log *logrus.Logger, metrics *Metrics) *Scheduler {
 	return &Scheduler{
 		log:     log,
 		cron:    cron.New(),
 		jobs:    make(map[string]cron.EntryID),
-		metrics: NewMetrics("panda_pulse"),
+		metrics: metrics,
 	}
 }
 

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -25,7 +25,7 @@ func TestScheduler(t *testing.T) {
 	t.Run("NewScheduler", func(t *testing.T) {
 		setupTest(t)
 		log := logrus.New()
-		s := NewScheduler(log)
+		s := NewScheduler(log, NewMetrics("test"))
 		require.NotNil(t, s)
 		require.NotNil(t, s.cron)
 		require.NotNil(t, s.jobs)
@@ -33,7 +33,7 @@ func TestScheduler(t *testing.T) {
 
 	t.Run("AddJob", func(t *testing.T) {
 		setupTest(t)
-		s := NewScheduler(logrus.New())
+		s := NewScheduler(logrus.New(), NewMetrics("test"))
 		s.Start()
 		defer s.Stop()
 
@@ -55,7 +55,7 @@ func TestScheduler(t *testing.T) {
 
 	t.Run("AddJob_InvalidSchedule", func(t *testing.T) {
 		setupTest(t)
-		s := NewScheduler(logrus.New())
+		s := NewScheduler(logrus.New(), NewMetrics("test"))
 
 		err := s.AddJob("test", "invalid", func(ctx context.Context) error {
 			return nil
@@ -66,7 +66,7 @@ func TestScheduler(t *testing.T) {
 
 	t.Run("AddJob_Replaces", func(t *testing.T) {
 		setupTest(t)
-		s := NewScheduler(logrus.New())
+		s := NewScheduler(logrus.New(), NewMetrics("test"))
 
 		// Add initial job.
 		require.NoError(t, s.AddJob("test", "* * * * *", func(ctx context.Context) error {
@@ -87,7 +87,7 @@ func TestScheduler(t *testing.T) {
 
 	t.Run("RemoveJob", func(t *testing.T) {
 		setupTest(t)
-		s := NewScheduler(logrus.New())
+		s := NewScheduler(logrus.New(), NewMetrics("test"))
 		s.Start()
 		defer s.Stop()
 
@@ -111,14 +111,14 @@ func TestScheduler(t *testing.T) {
 
 	t.Run("RemoveJob_NonExistent", func(t *testing.T) {
 		setupTest(t)
-		s := NewScheduler(logrus.New())
+		s := NewScheduler(logrus.New(), NewMetrics("test"))
 		// Should not panic.
 		s.RemoveJob("nonexistent")
 	})
 
 	t.Run("Job_Execution", func(t *testing.T) {
 		setupTest(t)
-		s := NewScheduler(logrus.New())
+		s := NewScheduler(logrus.New(), NewMetrics("test"))
 
 		var wg sync.WaitGroup
 		wg.Add(1)
@@ -153,7 +153,7 @@ func TestScheduler(t *testing.T) {
 		setupTest(t)
 		var logBuf logrus.Logger
 		log := &logBuf
-		s := NewScheduler(log)
+		s := NewScheduler(log, NewMetrics("test"))
 
 		var wg sync.WaitGroup
 		wg.Add(1)
@@ -172,7 +172,7 @@ func TestScheduler(t *testing.T) {
 
 	t.Run("Concurrent_Operations", func(t *testing.T) {
 		setupTest(t)
-		s := NewScheduler(logrus.New())
+		s := NewScheduler(logrus.New(), NewMetrics("test"))
 		s.Start()
 		defer s.Stop()
 

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -40,6 +40,7 @@ func TestScheduler(t *testing.T) {
 		jobRan := make(chan bool, 1)
 		err := s.AddJob("test", "@every 1s", func(ctx context.Context) error {
 			jobRan <- true
+
 			return nil
 		})
 
@@ -71,6 +72,7 @@ func TestScheduler(t *testing.T) {
 		require.NoError(t, s.AddJob("test", "* * * * *", func(ctx context.Context) error {
 			return nil
 		}))
+
 		firstID := s.jobs["test"]
 
 		// Replace with new job.
@@ -92,6 +94,7 @@ func TestScheduler(t *testing.T) {
 		jobRan := make(chan bool, 1)
 		err := s.AddJob("test", "@every 1s", func(ctx context.Context) error {
 			jobRan <- true
+
 			return nil
 		})
 		assert.NoError(t, err)

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/ethpandaops/panda-pulse/pkg/discord/mock"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -131,20 +132,20 @@ func (h *testHelper) createConfig() *Config {
 }
 
 func TestService(t *testing.T) {
-	ctx := context.Background()
-	helper := newTestHelper(t)
-	helper.setup(ctx)
-	defer helper.teardown(ctx)
-
 	t.Run("Start_And_Stop", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
+		setupTest(t)
+		helper := newTestHelper(t)
+		ctx := context.Background()
+		helper.setup(ctx)
+		defer helper.teardown(ctx)
 
 		cfg := helper.createConfig()
 		svc, err := NewService(ctx, helper.log, cfg)
 		require.NoError(t, err)
 
 		// Replace the real bot with our mock
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
 		mockBot := mock.NewMockBot(ctrl)
 
 		// Set expectations
@@ -183,4 +184,10 @@ func TestService(t *testing.T) {
 		// Stop service.
 		require.NoError(t, svc.Stop(ctx))
 	})
+}
+
+func setupTest(t *testing.T) {
+	t.Helper()
+
+	prometheus.DefaultRegisterer = prometheus.NewRegistry()
 }

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/ethpandaops/panda-pulse/pkg/discord/mock"
+	"github.com/ethpandaops/panda-pulse/pkg/queue"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -157,6 +158,7 @@ func TestService(t *testing.T) {
 		mockBot.EXPECT().GetScheduler().Return(nil).AnyTimes()
 		mockBot.EXPECT().GetSession().Return(nil).AnyTimes()
 		mockBot.EXPECT().GetHive().Return(nil).AnyTimes()
+		mockBot.EXPECT().GetQueues().Return([]queue.Queuer{}).Times(2) // Called during Start and Stop
 
 		svc.bot = mockBot
 

--- a/pkg/store/checks.go
+++ b/pkg/store/checks.go
@@ -32,8 +32,8 @@ type ChecksRepo struct {
 }
 
 // NewChecksRepo creates a new ChecksRepo.
-func NewChecksRepo(ctx context.Context, log *logrus.Logger, cfg *S3Config) (*ChecksRepo, error) {
-	baseRepo, err := NewBaseRepo(ctx, log, cfg)
+func NewChecksRepo(ctx context.Context, log *logrus.Logger, cfg *S3Config, metrics *Metrics) (*ChecksRepo, error) {
+	baseRepo, err := NewBaseRepo(ctx, log, cfg, metrics)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create base repo: %w", err)
 	}

--- a/pkg/store/checks.go
+++ b/pkg/store/checks.go
@@ -60,6 +60,7 @@ func (s *ChecksRepo) List(ctx context.Context) ([]*CheckArtifact, error) {
 		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			s.observeOperation("list", "checks", err)
+
 			return nil, fmt.Errorf("failed to list artifacts: %w", err)
 		}
 
@@ -100,6 +101,7 @@ func (s *ChecksRepo) List(ctx context.Context) ([]*CheckArtifact, error) {
 				artifact, err := s.getArtifact(ctx, *obj.Key)
 				if err != nil {
 					s.log.Errorf("Failed to get artifact %s: %v", *obj.Key, err)
+
 					continue
 				}
 
@@ -123,6 +125,7 @@ func (s *ChecksRepo) List(ctx context.Context) ([]*CheckArtifact, error) {
 	}
 
 	s.metrics.objectsTotal.WithLabelValues("checks").Set(float64(len(artifacts)))
+
 	return artifacts, nil
 }
 
@@ -247,6 +250,7 @@ func (s *ChecksRepo) GetArtifact(ctx context.Context, network, client, checkID, 
 	})
 	if err != nil {
 		s.observeOperation("get", "checks", err)
+
 		return nil, fmt.Errorf("failed to get artifact: %w", err)
 	}
 
@@ -256,6 +260,7 @@ func (s *ChecksRepo) GetArtifact(ctx context.Context, network, client, checkID, 
 	content, err := io.ReadAll(output.Body)
 	if err != nil {
 		s.observeOperation("get", "checks", err)
+
 		return nil, fmt.Errorf("failed to read artifact content: %w", err)
 	}
 

--- a/pkg/store/checks_test.go
+++ b/pkg/store/checks_test.go
@@ -17,14 +17,14 @@ func TestChecksRepo(t *testing.T) {
 
 	t.Run("NewChecksRepo", func(t *testing.T) {
 		setupTest(t)
-		repo, err := NewChecksRepo(ctx, helper.log, helper.cfg)
+		repo, err := NewChecksRepo(ctx, helper.log, helper.cfg, NewMetrics("test"))
 		require.NoError(t, err)
 		require.NotNil(t, repo)
 	})
 
 	t.Run("List_Empty", func(t *testing.T) {
 		setupTest(t)
-		repo, err := NewChecksRepo(ctx, helper.log, helper.cfg)
+		repo, err := NewChecksRepo(ctx, helper.log, helper.cfg, NewMetrics("test"))
 		require.NoError(t, err)
 
 		artifacts, err := repo.List(ctx)
@@ -34,7 +34,7 @@ func TestChecksRepo(t *testing.T) {
 
 	t.Run("Persist_And_List", func(t *testing.T) {
 		setupTest(t)
-		repo, err := NewChecksRepo(ctx, helper.log, helper.cfg)
+		repo, err := NewChecksRepo(ctx, helper.log, helper.cfg, NewMetrics("test"))
 		require.NoError(t, err)
 
 		artifact := &CheckArtifact{
@@ -62,7 +62,7 @@ func TestChecksRepo(t *testing.T) {
 
 	t.Run("GetArtifact", func(t *testing.T) {
 		setupTest(t)
-		repo, err := NewChecksRepo(ctx, helper.log, helper.cfg)
+		repo, err := NewChecksRepo(ctx, helper.log, helper.cfg, NewMetrics("test"))
 		require.NoError(t, err)
 
 		content := []byte("test log content")
@@ -86,7 +86,7 @@ func TestChecksRepo(t *testing.T) {
 
 	t.Run("Purge", func(t *testing.T) {
 		setupTest(t)
-		repo, err := NewChecksRepo(ctx, helper.log, helper.cfg)
+		repo, err := NewChecksRepo(ctx, helper.log, helper.cfg, NewMetrics("test"))
 		require.NoError(t, err)
 
 		artifact := &CheckArtifact{
@@ -109,7 +109,7 @@ func TestChecksRepo(t *testing.T) {
 
 	t.Run("Purge_Invalid_Identifiers", func(t *testing.T) {
 		setupTest(t)
-		repo, err := NewChecksRepo(ctx, helper.log, helper.cfg)
+		repo, err := NewChecksRepo(ctx, helper.log, helper.cfg, NewMetrics("test"))
 		require.NoError(t, err)
 
 		err = repo.Purge(ctx, "test-net", "test-client") // Missing checkID
@@ -119,7 +119,7 @@ func TestChecksRepo(t *testing.T) {
 
 	t.Run("Key_Generation", func(t *testing.T) {
 		setupTest(t)
-		repo, err := NewChecksRepo(ctx, helper.log, helper.cfg)
+		repo, err := NewChecksRepo(ctx, helper.log, helper.cfg, NewMetrics("test"))
 		require.NoError(t, err)
 
 		artifact := &CheckArtifact{
@@ -135,7 +135,7 @@ func TestChecksRepo(t *testing.T) {
 
 	t.Run("Key_Nil_Artifact", func(t *testing.T) {
 		setupTest(t)
-		repo, err := NewChecksRepo(ctx, helper.log, helper.cfg)
+		repo, err := NewChecksRepo(ctx, helper.log, helper.cfg, NewMetrics("test"))
 		require.NoError(t, err)
 
 		key := repo.Key(nil)
@@ -144,21 +144,21 @@ func TestChecksRepo(t *testing.T) {
 
 	t.Run("GetBucket", func(t *testing.T) {
 		setupTest(t)
-		repo, err := NewChecksRepo(ctx, helper.log, helper.cfg)
+		repo, err := NewChecksRepo(ctx, helper.log, helper.cfg, NewMetrics("test"))
 		require.NoError(t, err)
 		assert.Equal(t, testBucket, repo.GetBucket())
 	})
 
 	t.Run("GetPrefix", func(t *testing.T) {
 		setupTest(t)
-		repo, err := NewChecksRepo(ctx, helper.log, helper.cfg)
+		repo, err := NewChecksRepo(ctx, helper.log, helper.cfg, NewMetrics("test"))
 		require.NoError(t, err)
 		assert.Equal(t, "test", repo.GetPrefix())
 	})
 
 	t.Run("GetStore", func(t *testing.T) {
 		setupTest(t)
-		repo, err := NewChecksRepo(ctx, helper.log, helper.cfg)
+		repo, err := NewChecksRepo(ctx, helper.log, helper.cfg, NewMetrics("test"))
 		require.NoError(t, err)
 		assert.NotNil(t, repo.GetStore())
 	})

--- a/pkg/store/checks_test.go
+++ b/pkg/store/checks_test.go
@@ -16,12 +16,14 @@ func TestChecksRepo(t *testing.T) {
 	defer helper.teardown(ctx)
 
 	t.Run("NewChecksRepo", func(t *testing.T) {
+		setupTest(t)
 		repo, err := NewChecksRepo(ctx, helper.log, helper.cfg)
 		require.NoError(t, err)
 		require.NotNil(t, repo)
 	})
 
 	t.Run("List_Empty", func(t *testing.T) {
+		setupTest(t)
 		repo, err := NewChecksRepo(ctx, helper.log, helper.cfg)
 		require.NoError(t, err)
 
@@ -31,6 +33,7 @@ func TestChecksRepo(t *testing.T) {
 	})
 
 	t.Run("Persist_And_List", func(t *testing.T) {
+		setupTest(t)
 		repo, err := NewChecksRepo(ctx, helper.log, helper.cfg)
 		require.NoError(t, err)
 
@@ -58,6 +61,7 @@ func TestChecksRepo(t *testing.T) {
 	})
 
 	t.Run("GetArtifact", func(t *testing.T) {
+		setupTest(t)
 		repo, err := NewChecksRepo(ctx, helper.log, helper.cfg)
 		require.NoError(t, err)
 
@@ -81,6 +85,7 @@ func TestChecksRepo(t *testing.T) {
 	})
 
 	t.Run("Purge", func(t *testing.T) {
+		setupTest(t)
 		repo, err := NewChecksRepo(ctx, helper.log, helper.cfg)
 		require.NoError(t, err)
 
@@ -103,6 +108,7 @@ func TestChecksRepo(t *testing.T) {
 	})
 
 	t.Run("Purge_Invalid_Identifiers", func(t *testing.T) {
+		setupTest(t)
 		repo, err := NewChecksRepo(ctx, helper.log, helper.cfg)
 		require.NoError(t, err)
 
@@ -112,6 +118,7 @@ func TestChecksRepo(t *testing.T) {
 	})
 
 	t.Run("Key_Generation", func(t *testing.T) {
+		setupTest(t)
 		repo, err := NewChecksRepo(ctx, helper.log, helper.cfg)
 		require.NoError(t, err)
 
@@ -127,6 +134,7 @@ func TestChecksRepo(t *testing.T) {
 	})
 
 	t.Run("Key_Nil_Artifact", func(t *testing.T) {
+		setupTest(t)
 		repo, err := NewChecksRepo(ctx, helper.log, helper.cfg)
 		require.NoError(t, err)
 
@@ -135,18 +143,21 @@ func TestChecksRepo(t *testing.T) {
 	})
 
 	t.Run("GetBucket", func(t *testing.T) {
+		setupTest(t)
 		repo, err := NewChecksRepo(ctx, helper.log, helper.cfg)
 		require.NoError(t, err)
 		assert.Equal(t, testBucket, repo.GetBucket())
 	})
 
 	t.Run("GetPrefix", func(t *testing.T) {
+		setupTest(t)
 		repo, err := NewChecksRepo(ctx, helper.log, helper.cfg)
 		require.NoError(t, err)
 		assert.Equal(t, "test", repo.GetPrefix())
 	})
 
 	t.Run("GetStore", func(t *testing.T) {
+		setupTest(t)
 		repo, err := NewChecksRepo(ctx, helper.log, helper.cfg)
 		require.NoError(t, err)
 		assert.NotNil(t, repo.GetStore())

--- a/pkg/store/mentions.go
+++ b/pkg/store/mentions.go
@@ -31,8 +31,8 @@ type MentionsRepo struct {
 }
 
 // NewMentionsRepo creates a new MentionsRepo.
-func NewMentionsRepo(ctx context.Context, log *logrus.Logger, cfg *S3Config) (*MentionsRepo, error) {
-	baseRepo, err := NewBaseRepo(ctx, log, cfg)
+func NewMentionsRepo(ctx context.Context, log *logrus.Logger, cfg *S3Config, metrics *Metrics) (*MentionsRepo, error) {
+	baseRepo, err := NewBaseRepo(ctx, log, cfg, metrics)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create base repo: %w", err)
 	}

--- a/pkg/store/mentions.go
+++ b/pkg/store/mentions.go
@@ -59,6 +59,7 @@ func (s *MentionsRepo) List(ctx context.Context) ([]*ClientMention, error) {
 		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			s.observeOperation("list", "mentions", err)
+
 			return nil, fmt.Errorf("failed to list mentions: %w", err)
 		}
 
@@ -77,6 +78,7 @@ func (s *MentionsRepo) List(ctx context.Context) ([]*ClientMention, error) {
 	}
 
 	s.metrics.objectsTotal.WithLabelValues("mentions").Set(float64(len(mentions)))
+
 	return mentions, nil
 }
 
@@ -107,6 +109,7 @@ func (s *MentionsRepo) Get(ctx context.Context, network, client string) (*Client
 	}
 
 	s.observeOperation("get", "mentions", nil)
+
 	return mention, nil
 }
 
@@ -117,6 +120,7 @@ func (s *MentionsRepo) Persist(ctx context.Context, mention *ClientMention) erro
 	data, err := json.Marshal(mention)
 	if err != nil {
 		s.observeOperation("persist", "mentions", err)
+
 		return fmt.Errorf("failed to marshal mention: %w", err)
 	}
 
@@ -128,10 +132,12 @@ func (s *MentionsRepo) Persist(ctx context.Context, mention *ClientMention) erro
 		Body:   bytes.NewReader(data),
 	}); err != nil {
 		s.observeOperation("persist", "mentions", err)
+
 		return fmt.Errorf("failed to put mention: %w", err)
 	}
 
 	s.observeOperation("persist", "mentions", nil)
+
 	return nil
 }
 
@@ -150,10 +156,12 @@ func (s *MentionsRepo) Purge(ctx context.Context, identifiers ...string) error {
 		Key:    aws.String(s.Key(&ClientMention{Network: network, Client: client})),
 	}); err != nil {
 		s.observeOperation("purge", "mentions", err)
+
 		return fmt.Errorf("failed to delete mention: %w", err)
 	}
 
 	s.observeOperation("purge", "mentions", nil)
+
 	return nil
 }
 

--- a/pkg/store/mentions_test.go
+++ b/pkg/store/mentions_test.go
@@ -17,14 +17,14 @@ func TestMentionsRepo(t *testing.T) {
 
 	t.Run("NewMentionsRepo", func(t *testing.T) {
 		setupTest(t)
-		repo, err := NewMentionsRepo(ctx, helper.log, helper.cfg)
+		repo, err := NewMentionsRepo(ctx, helper.log, helper.cfg, NewMetrics("test"))
 		require.NoError(t, err)
 		require.NotNil(t, repo)
 	})
 
 	t.Run("List_Empty", func(t *testing.T) {
 		setupTest(t)
-		repo, err := NewMentionsRepo(ctx, helper.log, helper.cfg)
+		repo, err := NewMentionsRepo(ctx, helper.log, helper.cfg, NewMetrics("test"))
 		require.NoError(t, err)
 
 		mentions, err := repo.List(ctx)
@@ -34,7 +34,7 @@ func TestMentionsRepo(t *testing.T) {
 
 	t.Run("Persist_And_List", func(t *testing.T) {
 		setupTest(t)
-		repo, err := NewMentionsRepo(ctx, helper.log, helper.cfg)
+		repo, err := NewMentionsRepo(ctx, helper.log, helper.cfg, NewMetrics("test"))
 		require.NoError(t, err)
 
 		mention := &ClientMention{
@@ -61,7 +61,7 @@ func TestMentionsRepo(t *testing.T) {
 
 	t.Run("Get_NonExistent", func(t *testing.T) {
 		setupTest(t)
-		repo, err := NewMentionsRepo(ctx, helper.log, helper.cfg)
+		repo, err := NewMentionsRepo(ctx, helper.log, helper.cfg, NewMetrics("test"))
 		require.NoError(t, err)
 
 		mention, err := repo.Get(ctx, "non-existent-net", "non-existent-client")
@@ -75,7 +75,7 @@ func TestMentionsRepo(t *testing.T) {
 
 	t.Run("Get_Existing", func(t *testing.T) {
 		setupTest(t)
-		repo, err := NewMentionsRepo(ctx, helper.log, helper.cfg)
+		repo, err := NewMentionsRepo(ctx, helper.log, helper.cfg, NewMetrics("test"))
 		require.NoError(t, err)
 
 		original := &ClientMention{
@@ -100,7 +100,7 @@ func TestMentionsRepo(t *testing.T) {
 
 	t.Run("Purge", func(t *testing.T) {
 		setupTest(t)
-		repo, err := NewMentionsRepo(ctx, helper.log, helper.cfg)
+		repo, err := NewMentionsRepo(ctx, helper.log, helper.cfg, NewMetrics("test"))
 		require.NoError(t, err)
 
 		mention := &ClientMention{
@@ -121,7 +121,7 @@ func TestMentionsRepo(t *testing.T) {
 
 	t.Run("Purge_Invalid_Identifiers", func(t *testing.T) {
 		setupTest(t)
-		repo, err := NewMentionsRepo(ctx, helper.log, helper.cfg)
+		repo, err := NewMentionsRepo(ctx, helper.log, helper.cfg, NewMetrics("test"))
 		require.NoError(t, err)
 
 		err = repo.Purge(ctx, "test-net") // Missing client identifier
@@ -131,7 +131,7 @@ func TestMentionsRepo(t *testing.T) {
 
 	t.Run("Key_Generation", func(t *testing.T) {
 		setupTest(t)
-		repo, err := NewMentionsRepo(ctx, helper.log, helper.cfg)
+		repo, err := NewMentionsRepo(ctx, helper.log, helper.cfg, NewMetrics("test"))
 		require.NoError(t, err)
 
 		mention := &ClientMention{
@@ -145,7 +145,7 @@ func TestMentionsRepo(t *testing.T) {
 
 	t.Run("Key_Nil_Mention", func(t *testing.T) {
 		setupTest(t)
-		repo, err := NewMentionsRepo(ctx, helper.log, helper.cfg)
+		repo, err := NewMentionsRepo(ctx, helper.log, helper.cfg, NewMetrics("test"))
 		require.NoError(t, err)
 
 		key := repo.Key(nil)

--- a/pkg/store/mentions_test.go
+++ b/pkg/store/mentions_test.go
@@ -16,12 +16,14 @@ func TestMentionsRepo(t *testing.T) {
 	defer helper.teardown(ctx)
 
 	t.Run("NewMentionsRepo", func(t *testing.T) {
+		setupTest(t)
 		repo, err := NewMentionsRepo(ctx, helper.log, helper.cfg)
 		require.NoError(t, err)
 		require.NotNil(t, repo)
 	})
 
 	t.Run("List_Empty", func(t *testing.T) {
+		setupTest(t)
 		repo, err := NewMentionsRepo(ctx, helper.log, helper.cfg)
 		require.NoError(t, err)
 
@@ -31,6 +33,7 @@ func TestMentionsRepo(t *testing.T) {
 	})
 
 	t.Run("Persist_And_List", func(t *testing.T) {
+		setupTest(t)
 		repo, err := NewMentionsRepo(ctx, helper.log, helper.cfg)
 		require.NoError(t, err)
 
@@ -57,6 +60,7 @@ func TestMentionsRepo(t *testing.T) {
 	})
 
 	t.Run("Get_NonExistent", func(t *testing.T) {
+		setupTest(t)
 		repo, err := NewMentionsRepo(ctx, helper.log, helper.cfg)
 		require.NoError(t, err)
 
@@ -70,6 +74,7 @@ func TestMentionsRepo(t *testing.T) {
 	})
 
 	t.Run("Get_Existing", func(t *testing.T) {
+		setupTest(t)
 		repo, err := NewMentionsRepo(ctx, helper.log, helper.cfg)
 		require.NoError(t, err)
 
@@ -94,6 +99,7 @@ func TestMentionsRepo(t *testing.T) {
 	})
 
 	t.Run("Purge", func(t *testing.T) {
+		setupTest(t)
 		repo, err := NewMentionsRepo(ctx, helper.log, helper.cfg)
 		require.NoError(t, err)
 
@@ -114,6 +120,7 @@ func TestMentionsRepo(t *testing.T) {
 	})
 
 	t.Run("Purge_Invalid_Identifiers", func(t *testing.T) {
+		setupTest(t)
 		repo, err := NewMentionsRepo(ctx, helper.log, helper.cfg)
 		require.NoError(t, err)
 
@@ -123,6 +130,7 @@ func TestMentionsRepo(t *testing.T) {
 	})
 
 	t.Run("Key_Generation", func(t *testing.T) {
+		setupTest(t)
 		repo, err := NewMentionsRepo(ctx, helper.log, helper.cfg)
 		require.NoError(t, err)
 
@@ -136,6 +144,7 @@ func TestMentionsRepo(t *testing.T) {
 	})
 
 	t.Run("Key_Nil_Mention", func(t *testing.T) {
+		setupTest(t)
 		repo, err := NewMentionsRepo(ctx, helper.log, helper.cfg)
 		require.NoError(t, err)
 

--- a/pkg/store/metrics.go
+++ b/pkg/store/metrics.go
@@ -1,0 +1,62 @@
+package store
+
+import "github.com/prometheus/client_golang/prometheus"
+
+type Metrics struct {
+	operationsTotal   *prometheus.CounterVec
+	operationErrors   *prometheus.CounterVec
+	operationDuration *prometheus.HistogramVec
+	objectsTotal      *prometheus.GaugeVec
+	objectSizeBytes   *prometheus.HistogramVec
+}
+
+func NewMetrics(namespace string) *Metrics {
+	m := &Metrics{
+		operationsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: "store",
+			Name:      "operations_total",
+			Help:      "Total number of S3 operations performed",
+		}, []string{"operation", "repository"}),
+
+		operationErrors: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: "store",
+			Name:      "operation_errors_total",
+			Help:      "Total number of S3 operation errors",
+		}, []string{"operation", "repository", "error_type"}),
+
+		operationDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: "store",
+			Name:      "operation_duration_seconds",
+			Help:      "Time taken to perform S3 operations",
+			Buckets:   []float64{0.1, 0.5, 1, 2, 5, 10},
+		}, []string{"operation", "repository"}),
+
+		objectsTotal: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: "store",
+			Name:      "objects_total",
+			Help:      "Total number of objects in storage",
+		}, []string{"repository"}),
+
+		objectSizeBytes: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: "store",
+			Name:      "object_size_bytes",
+			Help:      "Size of objects in storage",
+			Buckets:   []float64{1024, 10 * 1024, 100 * 1024, 1024 * 1024, 10 * 1024 * 1024},
+		}, []string{"repository"}),
+	}
+
+	prometheus.MustRegister(
+		m.operationsTotal,
+		m.operationErrors,
+		m.operationDuration,
+		m.objectsTotal,
+		m.objectSizeBytes,
+	)
+
+	return m
+}

--- a/pkg/store/monitor.go
+++ b/pkg/store/monitor.go
@@ -61,6 +61,7 @@ func (s *MonitorRepo) List(ctx context.Context) ([]*MonitorAlert, error) {
 		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			s.observeOperation("list", "monitor", err)
+
 			return nil, fmt.Errorf("failed to list alerts: %w", err)
 		}
 
@@ -81,6 +82,7 @@ func (s *MonitorRepo) List(ctx context.Context) ([]*MonitorAlert, error) {
 	}
 
 	s.metrics.objectsTotal.WithLabelValues("monitor").Set(float64(len(alerts)))
+
 	return alerts, nil
 }
 
@@ -91,6 +93,7 @@ func (s *MonitorRepo) Persist(ctx context.Context, alert *MonitorAlert) error {
 	data, err := json.Marshal(alert)
 	if err != nil {
 		s.observeOperation("persist", "monitor", err)
+
 		return fmt.Errorf("failed to marshal alert: %w", err)
 	}
 
@@ -102,10 +105,12 @@ func (s *MonitorRepo) Persist(ctx context.Context, alert *MonitorAlert) error {
 		Body:   bytes.NewReader(data),
 	}); err != nil {
 		s.observeOperation("persist", "monitor", err)
+
 		return fmt.Errorf("failed to put alert: %w", err)
 	}
 
 	s.observeOperation("persist", "monitor", nil)
+
 	return nil
 }
 

--- a/pkg/store/monitor.go
+++ b/pkg/store/monitor.go
@@ -33,8 +33,8 @@ type MonitorAlert struct {
 }
 
 // NewMonitorRepo creates a new MonitorRepo.
-func NewMonitorRepo(ctx context.Context, log *logrus.Logger, cfg *S3Config) (*MonitorRepo, error) {
-	baseRepo, err := NewBaseRepo(ctx, log, cfg)
+func NewMonitorRepo(ctx context.Context, log *logrus.Logger, cfg *S3Config, metrics *Metrics) (*MonitorRepo, error) {
+	baseRepo, err := NewBaseRepo(ctx, log, cfg, metrics)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create base repo: %w", err)
 	}

--- a/pkg/store/monitor.go
+++ b/pkg/store/monitor.go
@@ -46,6 +46,8 @@ func NewMonitorRepo(ctx context.Context, log *logrus.Logger, cfg *S3Config) (*Mo
 
 // List implements Repository[*MonitorAlert].
 func (s *MonitorRepo) List(ctx context.Context) ([]*MonitorAlert, error) {
+	defer s.trackDuration("list", "monitor")()
+
 	var (
 		input = &s3.ListObjectsV2Input{
 			Bucket: aws.String(s.bucket),
@@ -58,6 +60,7 @@ func (s *MonitorRepo) List(ctx context.Context) ([]*MonitorAlert, error) {
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(ctx)
 		if err != nil {
+			s.observeOperation("list", "monitor", err)
 			return nil, fmt.Errorf("failed to list alerts: %w", err)
 		}
 
@@ -77,24 +80,32 @@ func (s *MonitorRepo) List(ctx context.Context) ([]*MonitorAlert, error) {
 		}
 	}
 
+	s.metrics.objectsTotal.WithLabelValues("monitor").Set(float64(len(alerts)))
 	return alerts, nil
 }
 
 // Persist implements Repository[*MonitorAlert].
 func (s *MonitorRepo) Persist(ctx context.Context, alert *MonitorAlert) error {
+	defer s.trackDuration("persist", "monitor")()
+
 	data, err := json.Marshal(alert)
 	if err != nil {
+		s.observeOperation("persist", "monitor", err)
 		return fmt.Errorf("failed to marshal alert: %w", err)
 	}
+
+	s.metrics.objectSizeBytes.WithLabelValues("monitor").Observe(float64(len(data)))
 
 	if _, err = s.store.PutObject(ctx, &s3.PutObjectInput{
 		Bucket: aws.String(s.bucket),
 		Key:    aws.String(s.Key(alert)),
 		Body:   bytes.NewReader(data),
 	}); err != nil {
+		s.observeOperation("persist", "monitor", err)
 		return fmt.Errorf("failed to put alert: %w", err)
 	}
 
+	s.observeOperation("persist", "monitor", nil)
 	return nil
 }
 

--- a/pkg/store/monitor_test.go
+++ b/pkg/store/monitor_test.go
@@ -17,12 +17,14 @@ func TestMonitorRepo(t *testing.T) {
 	defer helper.teardown(ctx)
 
 	t.Run("NewMonitorRepo", func(t *testing.T) {
+		setupTest(t)
 		repo, err := NewMonitorRepo(ctx, helper.log, helper.cfg)
 		require.NoError(t, err)
 		require.NotNil(t, repo)
 	})
 
 	t.Run("List_Empty", func(t *testing.T) {
+		setupTest(t)
 		repo, err := NewMonitorRepo(ctx, helper.log, helper.cfg)
 		require.NoError(t, err)
 
@@ -32,6 +34,7 @@ func TestMonitorRepo(t *testing.T) {
 	})
 
 	t.Run("Persist_And_List", func(t *testing.T) {
+		setupTest(t)
 		repo, err := NewMonitorRepo(ctx, helper.log, helper.cfg)
 		require.NoError(t, err)
 
@@ -64,6 +67,7 @@ func TestMonitorRepo(t *testing.T) {
 	})
 
 	t.Run("Purge", func(t *testing.T) {
+		setupTest(t)
 		repo, err := NewMonitorRepo(ctx, helper.log, helper.cfg)
 		require.NoError(t, err)
 
@@ -84,6 +88,7 @@ func TestMonitorRepo(t *testing.T) {
 	})
 
 	t.Run("Purge_Invalid_Identifiers", func(t *testing.T) {
+		setupTest(t)
 		repo, err := NewMonitorRepo(ctx, helper.log, helper.cfg)
 		require.NoError(t, err)
 
@@ -93,6 +98,7 @@ func TestMonitorRepo(t *testing.T) {
 	})
 
 	t.Run("Key_Generation", func(t *testing.T) {
+		setupTest(t)
 		repo, err := NewMonitorRepo(ctx, helper.log, helper.cfg)
 		require.NoError(t, err)
 
@@ -106,6 +112,7 @@ func TestMonitorRepo(t *testing.T) {
 	})
 
 	t.Run("Key_Nil_Alert", func(t *testing.T) {
+		setupTest(t)
 		repo, err := NewMonitorRepo(ctx, helper.log, helper.cfg)
 		require.NoError(t, err)
 

--- a/pkg/store/monitor_test.go
+++ b/pkg/store/monitor_test.go
@@ -18,14 +18,14 @@ func TestMonitorRepo(t *testing.T) {
 
 	t.Run("NewMonitorRepo", func(t *testing.T) {
 		setupTest(t)
-		repo, err := NewMonitorRepo(ctx, helper.log, helper.cfg)
+		repo, err := NewMonitorRepo(ctx, helper.log, helper.cfg, NewMetrics("test"))
 		require.NoError(t, err)
 		require.NotNil(t, repo)
 	})
 
 	t.Run("List_Empty", func(t *testing.T) {
 		setupTest(t)
-		repo, err := NewMonitorRepo(ctx, helper.log, helper.cfg)
+		repo, err := NewMonitorRepo(ctx, helper.log, helper.cfg, NewMetrics("test"))
 		require.NoError(t, err)
 
 		alerts, err := repo.List(ctx)
@@ -35,7 +35,7 @@ func TestMonitorRepo(t *testing.T) {
 
 	t.Run("Persist_And_List", func(t *testing.T) {
 		setupTest(t)
-		repo, err := NewMonitorRepo(ctx, helper.log, helper.cfg)
+		repo, err := NewMonitorRepo(ctx, helper.log, helper.cfg, NewMetrics("test"))
 		require.NoError(t, err)
 
 		alert := &MonitorAlert{
@@ -68,7 +68,7 @@ func TestMonitorRepo(t *testing.T) {
 
 	t.Run("Purge", func(t *testing.T) {
 		setupTest(t)
-		repo, err := NewMonitorRepo(ctx, helper.log, helper.cfg)
+		repo, err := NewMonitorRepo(ctx, helper.log, helper.cfg, NewMetrics("test"))
 		require.NoError(t, err)
 
 		alert := &MonitorAlert{
@@ -89,7 +89,7 @@ func TestMonitorRepo(t *testing.T) {
 
 	t.Run("Purge_Invalid_Identifiers", func(t *testing.T) {
 		setupTest(t)
-		repo, err := NewMonitorRepo(ctx, helper.log, helper.cfg)
+		repo, err := NewMonitorRepo(ctx, helper.log, helper.cfg, NewMetrics("test"))
 		require.NoError(t, err)
 
 		err = repo.Purge(ctx, "test-net") // Missing client identifier
@@ -99,7 +99,7 @@ func TestMonitorRepo(t *testing.T) {
 
 	t.Run("Key_Generation", func(t *testing.T) {
 		setupTest(t)
-		repo, err := NewMonitorRepo(ctx, helper.log, helper.cfg)
+		repo, err := NewMonitorRepo(ctx, helper.log, helper.cfg, NewMetrics("test"))
 		require.NoError(t, err)
 
 		alert := &MonitorAlert{
@@ -113,7 +113,7 @@ func TestMonitorRepo(t *testing.T) {
 
 	t.Run("Key_Nil_Alert", func(t *testing.T) {
 		setupTest(t)
-		repo, err := NewMonitorRepo(ctx, helper.log, helper.cfg)
+		repo, err := NewMonitorRepo(ctx, helper.log, helper.cfg, NewMetrics("test"))
 		require.NoError(t, err)
 
 		key := repo.Key(nil)

--- a/pkg/store/repository.go
+++ b/pkg/store/repository.go
@@ -110,7 +110,7 @@ func (b *BaseRepo) GetS3Client() *s3.Client {
 	return b.store
 }
 
-// Add helper methods for metrics
+// observeOperation observes the operation and increments the metrics.
 func (b *BaseRepo) observeOperation(operation, repository string, err error) {
 	b.metrics.operationsTotal.WithLabelValues(operation, repository).Inc()
 
@@ -127,6 +127,7 @@ func (b *BaseRepo) observeOperation(operation, repository string, err error) {
 	}
 }
 
+// trackDuration tracks the duration of an operation and observes the metrics.
 func (b *BaseRepo) trackDuration(operation, repository string) func() {
 	start := time.Now()
 

--- a/pkg/store/repository.go
+++ b/pkg/store/repository.go
@@ -3,6 +3,8 @@ package store
 import (
 	"context"
 	"fmt"
+	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -30,10 +32,11 @@ type Repository[T any] interface {
 
 // BaseRepo contains common S3 functionality for all repositories.
 type BaseRepo struct {
-	store  *s3.Client
-	bucket string
-	prefix string
-	log    *logrus.Logger
+	store   *s3.Client
+	bucket  string
+	prefix  string
+	log     *logrus.Logger
+	metrics *Metrics
 }
 
 // S3Config contains the configuration for the S3 client.
@@ -72,10 +75,11 @@ func NewBaseRepo(ctx context.Context, log *logrus.Logger, cfg *S3Config) (BaseRe
 	}
 
 	return BaseRepo{
-		store:  s3.NewFromConfig(awsCfg, cfgOpts...),
-		bucket: cfg.Bucket,
-		prefix: cfg.Prefix,
-		log:    log,
+		store:   s3.NewFromConfig(awsCfg, cfgOpts...),
+		bucket:  cfg.Bucket,
+		prefix:  cfg.Prefix,
+		log:     log,
+		metrics: NewMetrics("panda_pulse"),
 	}, nil
 }
 
@@ -104,4 +108,29 @@ func (b *BaseRepo) VerifyConnection(ctx context.Context) error {
 // GetS3Client returns the underlying S3 client.
 func (b *BaseRepo) GetS3Client() *s3.Client {
 	return b.store
+}
+
+// Add helper methods for metrics
+func (b *BaseRepo) observeOperation(operation, repository string, err error) {
+	b.metrics.operationsTotal.WithLabelValues(operation, repository).Inc()
+
+	if err != nil {
+		errType := "unknown"
+
+		if strings.Contains(err.Error(), "context deadline exceeded") {
+			errType = "timeout"
+		} else if strings.Contains(err.Error(), "not found") {
+			errType = "not_found"
+		}
+
+		b.metrics.operationErrors.WithLabelValues(operation, repository, errType).Inc()
+	}
+}
+
+func (b *BaseRepo) trackDuration(operation, repository string) func() {
+	start := time.Now()
+
+	return func() {
+		b.metrics.operationDuration.WithLabelValues(operation, repository).Observe(time.Since(start).Seconds())
+	}
 }

--- a/pkg/store/repository.go
+++ b/pkg/store/repository.go
@@ -50,7 +50,7 @@ type S3Config struct {
 }
 
 // NewBaseRepo creates a new base repository with common S3 functionality.
-func NewBaseRepo(ctx context.Context, log *logrus.Logger, cfg *S3Config) (BaseRepo, error) {
+func NewBaseRepo(ctx context.Context, log *logrus.Logger, cfg *S3Config, metrics *Metrics) (BaseRepo, error) {
 	opts := []func(*config.LoadOptions) error{
 		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
 			cfg.AccessKeyID,
@@ -79,7 +79,7 @@ func NewBaseRepo(ctx context.Context, log *logrus.Logger, cfg *S3Config) (BaseRe
 		bucket:  cfg.Bucket,
 		prefix:  cfg.Prefix,
 		log:     log,
-		metrics: NewMetrics("panda_pulse"),
+		metrics: metrics,
 	}, nil
 }
 

--- a/pkg/store/repository_test.go
+++ b/pkg/store/repository_test.go
@@ -15,6 +15,7 @@ func TestBaseRepo(t *testing.T) {
 	defer helper.teardown(ctx)
 
 	t.Run("NewBaseRepo", func(t *testing.T) {
+		setupTest(t)
 		baseRepo := helper.createBaseRepo(ctx)
 		require.NotNil(t, baseRepo.store)
 		assert.Equal(t, testBucket, baseRepo.bucket)
@@ -34,6 +35,7 @@ func TestBaseRepo(t *testing.T) {
 	})
 
 	t.Run("Invalid_Credentials", func(t *testing.T) {
+		setupTest(t)
 		invalidCfg := *helper.cfg
 		invalidCfg.AccessKeyID = "invalid"
 		invalidCfg.SecretAccessKey = "invalid"
@@ -47,6 +49,7 @@ func TestBaseRepo(t *testing.T) {
 	})
 
 	t.Run("Invalid_Bucket", func(t *testing.T) {
+		setupTest(t)
 		invalidCfg := *helper.cfg
 		invalidCfg.Bucket = "nonexistent-bucket"
 
@@ -59,6 +62,7 @@ func TestBaseRepo(t *testing.T) {
 	})
 
 	t.Run("Invalid_Endpoint", func(t *testing.T) {
+		setupTest(t)
 		invalidCfg := *helper.cfg
 		invalidCfg.EndpointURL = "http://invalid:1234"
 

--- a/pkg/store/repository_test.go
+++ b/pkg/store/repository_test.go
@@ -40,7 +40,7 @@ func TestBaseRepo(t *testing.T) {
 		invalidCfg.AccessKeyID = "invalid"
 		invalidCfg.SecretAccessKey = "invalid"
 
-		_, err := NewBaseRepo(ctx, helper.log, &invalidCfg)
+		_, err := NewBaseRepo(ctx, helper.log, &invalidCfg, NewMetrics("test"))
 		require.NoError(t, err) // Creation should succeed as AWS SDK validates credentials lazily
 
 		baseRepo := helper.createBaseRepo(ctx)
@@ -53,7 +53,7 @@ func TestBaseRepo(t *testing.T) {
 		invalidCfg := *helper.cfg
 		invalidCfg.Bucket = "nonexistent-bucket"
 
-		baseRepo, err := NewBaseRepo(ctx, helper.log, &invalidCfg)
+		baseRepo, err := NewBaseRepo(ctx, helper.log, &invalidCfg, NewMetrics("test"))
 		require.NoError(t, err)
 
 		err = baseRepo.VerifyConnection(ctx)
@@ -66,7 +66,7 @@ func TestBaseRepo(t *testing.T) {
 		invalidCfg := *helper.cfg
 		invalidCfg.EndpointURL = "http://invalid:1234"
 
-		baseRepo, err := NewBaseRepo(ctx, helper.log, &invalidCfg)
+		baseRepo, err := NewBaseRepo(ctx, helper.log, &invalidCfg, NewMetrics("test"))
 		require.NoError(t, err)
 
 		err = baseRepo.VerifyConnection(ctx)

--- a/pkg/store/testing.go
+++ b/pkg/store/testing.go
@@ -108,7 +108,7 @@ func (h *testHelper) createBucket(ctx context.Context) {
 	h.t.Helper()
 	setupTest(h.t)
 
-	baseRepo, err := NewBaseRepo(ctx, h.log, h.cfg)
+	baseRepo, err := NewBaseRepo(ctx, h.log, h.cfg, NewMetrics("test"))
 	if err != nil {
 		h.t.Fatalf("Failed to create base repo: %v", err)
 	}
@@ -126,7 +126,7 @@ func (h *testHelper) createBaseRepo(ctx context.Context) BaseRepo {
 	h.t.Helper()
 	setupTest(h.t)
 
-	baseRepo, err := NewBaseRepo(ctx, h.log, h.cfg)
+	baseRepo, err := NewBaseRepo(ctx, h.log, h.cfg, NewMetrics("test"))
 	if err != nil {
 		h.t.Fatalf("Failed to create base repo: %v", err)
 	}

--- a/pkg/store/testing.go
+++ b/pkg/store/testing.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
@@ -105,6 +106,7 @@ func (h *testHelper) teardown(ctx context.Context) {
 
 func (h *testHelper) createBucket(ctx context.Context) {
 	h.t.Helper()
+	setupTest(h.t)
 
 	baseRepo, err := NewBaseRepo(ctx, h.log, h.cfg)
 	if err != nil {
@@ -122,6 +124,7 @@ func (h *testHelper) createBucket(ctx context.Context) {
 // createBaseRepo creates a new BaseRepo for testing.
 func (h *testHelper) createBaseRepo(ctx context.Context) BaseRepo {
 	h.t.Helper()
+	setupTest(h.t)
 
 	baseRepo, err := NewBaseRepo(ctx, h.log, h.cfg)
 	if err != nil {
@@ -129,4 +132,10 @@ func (h *testHelper) createBaseRepo(ctx context.Context) BaseRepo {
 	}
 
 	return baseRepo
+}
+
+func setupTest(t *testing.T) {
+	t.Helper()
+
+	prometheus.DefaultRegisterer = prometheus.NewRegistry()
 }


### PR DESCRIPTION
This PR branches off #27, making the queue slightly more generic and wrapping metrics around:

- `pkg/store`
- `pkg/scheduler`
- `pkg/queue`