### PR TITLE
feat(pkg/discord): implement /build command to trigger client builds

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -86,6 +86,7 @@ func setConfig(cfg *service.Config) {
 	cfg.DiscordToken = os.Getenv("DISCORD_BOT_TOKEN")
 	cfg.AccessKeyID = os.Getenv("AWS_ACCESS_KEY_ID")
 	cfg.SecretAccessKey = os.Getenv("AWS_SECRET_ACCESS_KEY")
+	cfg.GithubToken = os.Getenv("GITHUB_TOKEN")
 	cfg.S3Bucket = os.Getenv("S3_BUCKET")
 	cfg.S3BucketPrefix = os.Getenv("S3_BUCKET_PREFIX")
 	cfg.S3Region = os.Getenv("AWS_REGION")

--- a/pkg/clients/clients.go
+++ b/pkg/clients/clients.go
@@ -73,6 +73,38 @@ var (
 		ELNimbusel:   true,
 		"erigonTwo":  true, // Not in standard client list but tracked for pre-production.
 	}
+	// DefaultRepositories maps clients to their default source repositories.
+	DefaultRepositories = map[string]string{
+		CLLighthouse: "sigp/lighthouse",
+		CLPrysm:      "prysmaticlabs/prysm",
+		CLLodestar:   "chainsafe/lodestar",
+		CLNimbus:     "status-im/nimbus-eth2",
+		CLTeku:       "ConsenSys/teku",
+		CLGrandine:   "paradigmxyz/grandine",
+		ELNethermind: "NethermindEth/nethermind",
+		ELNimbusel:   "status-im/nimbus",
+		ELBesu:       "hyperledger/besu",
+		ELGeth:       "ethereum/go-ethereum",
+		ELReth:       "paradigmxyz/reth",
+		ELErigon:     "ledgerwatch/erigon",
+		ELEthereumJS: "ethereumjs/ethereumjs-monorepo",
+	}
+	// DefaultBranches maps clients to their default branches.
+	DefaultBranches = map[string]string{
+		CLLighthouse: "master",
+		CLPrysm:      "develop",
+		CLLodestar:   "main",
+		CLNimbus:     "unstable",
+		CLTeku:       "master",
+		CLGrandine:   "main",
+		ELNethermind: "master",
+		ELNimbusel:   "unstable",
+		ELBesu:       "main",
+		ELGeth:       "master",
+		ELReth:       "main",
+		ELErigon:     "devel",
+		ELEthereumJS: "master",
+	}
 )
 
 // IsCLClient returns true if the client is a consensus client.

--- a/pkg/discord/cmd/build/command.go
+++ b/pkg/discord/cmd/build/command.go
@@ -93,6 +93,21 @@ func (c *BuildCommand) Handle(s *discordgo.Session, i *discordgo.InteractionCrea
 		return
 	}
 
+	// Check permissions before executing command.
+	if !c.hasPermission(i.Member, s, i.GuildID, c.bot.GetRoleConfig()) {
+		if err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Content: common.NoPermissionError(fmt.Sprintf("%s %s", c.Name(), data.Options[0].Name)).Error(),
+				Flags:   discordgo.MessageFlagsEphemeral,
+			},
+		}); err != nil {
+			c.log.WithError(err).Error("Failed to respond with permission error")
+		}
+
+		return
+	}
+
 	var err error
 
 	switch data.Options[0].Name {

--- a/pkg/discord/cmd/build/command.go
+++ b/pkg/discord/cmd/build/command.go
@@ -15,15 +15,17 @@ const (
 
 // BuildCommand handles the /build command.
 type BuildCommand struct {
-	log *logrus.Logger
-	bot common.BotContext
+	log         *logrus.Logger
+	bot         common.BotContext
+	githubToken string
 }
 
 // NewBuildCommand creates a new build command.
-func NewBuildCommand(log *logrus.Logger, bot common.BotContext) *BuildCommand {
+func NewBuildCommand(log *logrus.Logger, bot common.BotContext, githubToken string) *BuildCommand {
 	return &BuildCommand{
-		log: log,
-		bot: bot,
+		log:         log,
+		bot:         bot,
+		githubToken: githubToken,
 	}
 }
 

--- a/pkg/discord/cmd/build/command.go
+++ b/pkg/discord/cmd/build/command.go
@@ -1,0 +1,117 @@
+package build
+
+import (
+	"fmt"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/ethpandaops/panda-pulse/pkg/discord/cmd/common"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	// DefaultRepository is the default repository for the eth-client-docker-image-builder.
+	DefaultRepository = "ethpandaops/eth-client-docker-image-builder"
+)
+
+// BuildCommand handles the /build command.
+type BuildCommand struct {
+	log *logrus.Logger
+	bot common.BotContext
+}
+
+// NewBuildCommand creates a new build command.
+func NewBuildCommand(log *logrus.Logger, bot common.BotContext) *BuildCommand {
+	return &BuildCommand{
+		log: log,
+		bot: bot,
+	}
+}
+
+// Name returns the name of the command.
+func (c *BuildCommand) Name() string {
+	return "build"
+}
+
+// Register registers the /build command with the given discord session.
+func (c *BuildCommand) Register(session *discordgo.Session) error {
+	var (
+		clientChoices = c.getClientChoices()
+	)
+
+	if _, err := session.ApplicationCommandCreate(session.State.User.ID, "", &discordgo.ApplicationCommand{
+		Name:        c.Name(),
+		Description: "Trigger client docker image builds",
+		Options: []*discordgo.ApplicationCommandOption{
+			{
+				Name:        "trigger",
+				Description: "Trigger a build for a specific client",
+				Type:        discordgo.ApplicationCommandOptionSubCommand,
+				Options: []*discordgo.ApplicationCommandOption{
+					{
+						Name:        "client",
+						Description: "Client to build",
+						Type:        discordgo.ApplicationCommandOptionString,
+						Required:    true,
+						Choices:     clientChoices,
+					},
+					{
+						Name:        "repository",
+						Description: "Source repository to build from",
+						Type:        discordgo.ApplicationCommandOptionString,
+						Required:    false,
+					},
+					{
+						Name:        "ref",
+						Description: "Branch, tag or SHA to build from",
+						Type:        discordgo.ApplicationCommandOptionString,
+						Required:    false,
+					},
+					{
+						Name:        "docker_tag",
+						Description: "Override target docker tag",
+						Type:        discordgo.ApplicationCommandOptionString,
+						Required:    false,
+					},
+				},
+			},
+		},
+	}); err != nil {
+		return fmt.Errorf("failed to register build command: %w", err)
+	}
+
+	return nil
+}
+
+// Handle handles the /build command.
+func (c *BuildCommand) Handle(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	if i.Type != discordgo.InteractionApplicationCommand {
+		return
+	}
+
+	data := i.ApplicationCommandData()
+	if data.Name != c.Name() {
+		return
+	}
+
+	var err error
+
+	switch data.Options[0].Name {
+	case "trigger":
+		err = c.handleTrigger(s, i, data.Options[0])
+	}
+
+	if err != nil {
+		c.log.Errorf("Command failed: %v", err)
+
+		respErr := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Content: fmt.Sprintf("Command failed: %v", err),
+				Flags:   discordgo.MessageFlagsEphemeral,
+			},
+		})
+		if respErr != nil {
+			c.log.Errorf("Failed to respond to interaction: %v", respErr)
+		}
+	}
+}

--- a/pkg/discord/cmd/build/trigger.go
+++ b/pkg/discord/cmd/build/trigger.go
@@ -1,0 +1,187 @@
+package build
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/ethpandaops/panda-pulse/pkg/clients"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	buildEmbedColor = 0x7289DA
+)
+
+// handleTrigger handles the trigger subcommand.
+func (c *BuildCommand) handleTrigger(s *discordgo.Session, i *discordgo.InteractionCreate, option *discordgo.ApplicationCommandInteractionDataOption) error {
+	// Send immediate response, discord requires an ACK with 3s, sometimes triggering
+	// the build can blow out, and then things will fall apart.
+	err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{
+			Content: fmt.Sprintf("🔄 Triggering build for **%s**...", option.Options[0].StringValue()),
+			Flags:   discordgo.MessageFlagsEphemeral,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to send initial response: %w", err)
+	}
+
+	// Get the client from the options.
+	client := option.Options[0].StringValue()
+
+	// Get optional parameters.
+	var repository, ref, dockerTag string
+
+	for _, opt := range option.Options[1:] {
+		switch opt.Name {
+		case "repository":
+			repository = opt.StringValue()
+		case "ref":
+			ref = opt.StringValue()
+		case "docker_tag":
+			dockerTag = opt.StringValue()
+		}
+	}
+
+	// Use defaults if not provided.
+	if repository == "" {
+		repository = clients.DefaultRepositories[client]
+	}
+
+	if ref == "" {
+		ref = clients.DefaultBranches[client]
+	}
+
+	c.log.WithFields(logrus.Fields{
+		"command":    "/build trigger",
+		"repository": repository,
+		"ref":        ref,
+		"docker_tag": dockerTag,
+		"user":       i.Member.User.Username,
+	}).Info("Received command")
+
+	// Trigger the workflow.
+	workflowURL, err := c.triggerWorkflow(client, repository, ref, dockerTag)
+	if err != nil {
+		if _, interactionErr := s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
+			Content: stringPtr(fmt.Sprintf("❌ Failed to trigger build for **%s**: %s", client, err)),
+		}); interactionErr != nil {
+			return fmt.Errorf("failed to edit response with error: %w (original error: %s)", interactionErr, err)
+		}
+
+		return nil // Already handled error by editing message
+	}
+
+	// Create success embed.
+	embed := &discordgo.MessageEmbed{
+		Title: fmt.Sprintf("🏗️ Build Triggered: %s", client),
+		Color: buildEmbedColor,
+		Fields: []*discordgo.MessageEmbedField{
+			{
+				Name:   "Repository",
+				Value:  fmt.Sprintf("`%s`", repository),
+				Inline: true,
+			},
+			{
+				Name:   "Branch/Tag",
+				Value:  fmt.Sprintf("`%s`", ref),
+				Inline: true,
+			},
+			{
+				Name:   "Workflow",
+				Value:  fmt.Sprintf("[View Build Status](%s)", workflowURL),
+				Inline: false,
+			},
+		},
+		URL:       workflowURL,
+		Timestamp: time.Now().Format(time.RFC3339),
+	}
+
+	// Add docker tag if specified.
+	if dockerTag != "" {
+		embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
+			Name:   "Docker Tag",
+			Value:  fmt.Sprintf("`%s`", dockerTag),
+			Inline: true,
+		})
+	}
+
+	// Add client logo if available.
+	if logo := clients.GetClientLogo(client); logo != "" {
+		embed.Thumbnail = &discordgo.MessageEmbedThumbnail{
+			URL: logo,
+		}
+	}
+
+	// Edit message with success embed.
+	if _, err = s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
+		Content: stringPtr(""),
+		Embeds:  &[]*discordgo.MessageEmbed{embed},
+	}); err != nil {
+		return fmt.Errorf("failed to edit response: %w", err)
+	}
+
+	return nil
+}
+
+// triggerWorkflow triggers the GitHub workflow for the given client.
+func (c *BuildCommand) triggerWorkflow(clientName, repository, ref, dockerTag string) (string, error) {
+	token := os.Getenv("GITHUB_TOKEN")
+	if token == "" {
+		return "", fmt.Errorf("GITHUB_TOKEN environment variable not set")
+	}
+
+	// Prepare the workflow inputs.
+	inputs := map[string]interface{}{
+		"repository": repository,
+		"ref":        ref,
+	}
+
+	if dockerTag != "" {
+		inputs["docker_tag"] = dockerTag
+	}
+
+	body := map[string]interface{}{
+		"ref":    "master", // `master` of DefaultRepository.
+		"inputs": inputs,
+	}
+
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal request body: %w", err)
+	}
+
+	req, err := http.NewRequest(
+		"POST",
+		fmt.Sprintf("https://api.github.com/repos/%s/actions/workflows/build-push-%s.yml/dispatches", DefaultRepository, clientName),
+		strings.NewReader(string(jsonBody)),
+	)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+
+	httpClient := &http.Client{}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to send request: %w", err)
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		return "", fmt.Errorf("workflow trigger failed with status: %d", resp.StatusCode)
+	}
+
+	return fmt.Sprintf("https://github.com/%s/actions/workflows/build-push-%s.yml", DefaultRepository, clientName), nil
+}

--- a/pkg/discord/cmd/build/trigger.go
+++ b/pkg/discord/cmd/build/trigger.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"os"
 	"strings"
 	"time"
 
@@ -132,11 +131,6 @@ func (c *BuildCommand) handleTrigger(s *discordgo.Session, i *discordgo.Interact
 
 // triggerWorkflow triggers the GitHub workflow for the given client.
 func (c *BuildCommand) triggerWorkflow(clientName, repository, ref, dockerTag string) (string, error) {
-	token := os.Getenv("GITHUB_TOKEN")
-	if token == "" {
-		return "", fmt.Errorf("GITHUB_TOKEN environment variable not set")
-	}
-
 	// Prepare the workflow inputs.
 	inputs := map[string]interface{}{
 		"repository": repository,
@@ -167,7 +161,7 @@ func (c *BuildCommand) triggerWorkflow(clientName, repository, ref, dockerTag st
 	}
 
 	req.Header.Set("Accept", "application/vnd.github.v3+json")
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Authorization", "Bearer "+c.githubToken)
 	req.Header.Set("Content-Type", "application/json")
 
 	httpClient := &http.Client{}

--- a/pkg/discord/cmd/build/utils.go
+++ b/pkg/discord/cmd/build/utils.go
@@ -1,8 +1,11 @@
 package build
 
 import (
+	"strings"
+
 	"github.com/bwmarrin/discordgo"
 	"github.com/ethpandaops/panda-pulse/pkg/clients"
+	"github.com/ethpandaops/panda-pulse/pkg/discord/cmd/common"
 )
 
 // getClientChoices returns the choices for client selection.
@@ -26,6 +29,40 @@ func (c *BuildCommand) getClientChoices() []*discordgo.ApplicationCommandOptionC
 	}
 
 	return choices
+}
+
+// hasPermission checks if a member has permission to execute the build command.
+// For the build command, any user with any team role or admin role can trigger builds.
+func (c *BuildCommand) hasPermission(member *discordgo.Member, session *discordgo.Session, guildID string, config *common.RoleConfig) bool {
+	// Check admin roles first.
+	for _, roleID := range member.Roles {
+		role, err := session.State.Role(guildID, roleID)
+		if err != nil {
+			continue
+		}
+
+		roleName := strings.ToLower(role.Name)
+		if config.AdminRoles[roleName] {
+			return true
+		}
+	}
+
+	// Check if user has any team role.
+	for _, roleID := range member.Roles {
+		role, err := session.State.Role(guildID, roleID)
+		if err != nil {
+			continue
+		}
+
+		roleName := strings.ToLower(role.Name)
+		for _, teamRole := range config.ClientRoles {
+			if strings.EqualFold(teamRole, roleName) {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 // stringPtr returns a pointer to the given string.

--- a/pkg/discord/cmd/build/utils.go
+++ b/pkg/discord/cmd/build/utils.go
@@ -1,0 +1,34 @@
+package build
+
+import (
+	"github.com/bwmarrin/discordgo"
+	"github.com/ethpandaops/panda-pulse/pkg/clients"
+)
+
+// getClientChoices returns the choices for client selection.
+func (c *BuildCommand) getClientChoices() []*discordgo.ApplicationCommandOptionChoice {
+	choices := make([]*discordgo.ApplicationCommandOptionChoice, 0)
+
+	// Add consensus clients
+	for _, client := range clients.CLClients {
+		choices = append(choices, &discordgo.ApplicationCommandOptionChoice{
+			Name:  client,
+			Value: client,
+		})
+	}
+
+	// Add execution clients
+	for _, client := range clients.ELClients {
+		choices = append(choices, &discordgo.ApplicationCommandOptionChoice{
+			Name:  client,
+			Value: client,
+		})
+	}
+
+	return choices
+}
+
+// stringPtr returns a pointer to the given string.
+func stringPtr(s string) *string {
+	return &s
+}

--- a/pkg/discord/config.go
+++ b/pkg/discord/config.go
@@ -10,6 +10,7 @@ import (
 // Config represents the configuration for the Discord bot.
 type Config struct {
 	DiscordToken string `yaml:"discordToken"`
+	GithubToken  string `yaml:"githubToken"`
 }
 
 // AsRoleConfig returns the role configuration.

--- a/pkg/service/config.go
+++ b/pkg/service/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	PromDatasourceID   string
 	AccessKeyID        string
 	SecretAccessKey    string
+	GithubToken        string
 	S3Bucket           string
 	S3BucketPrefix     string
 	S3Region           string
@@ -41,6 +42,7 @@ func (c *Config) AsS3Config() *store.S3Config {
 func (c *Config) AsDiscordConfig() *discord.Config {
 	return &discord.Config{
 		DiscordToken: c.DiscordToken,
+		GithubToken:  c.GithubToken,
 	}
 }
 

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/ethpandaops/panda-pulse/pkg/discord"
+	"github.com/ethpandaops/panda-pulse/pkg/discord/cmd/build"
 	"github.com/ethpandaops/panda-pulse/pkg/discord/cmd/checks"
 	"github.com/ethpandaops/panda-pulse/pkg/discord/cmd/common"
 	cmdhive "github.com/ethpandaops/panda-pulse/pkg/discord/cmd/hive"
@@ -105,6 +106,7 @@ func NewService(ctx context.Context, log *logrus.Logger, cfg *Config) (*Service,
 		checks.NewChecksCommand(log, bot),
 		mentions.NewMentionsCommand(log, bot),
 		cmdhive.NewHiveCommand(log, bot),
+		build.NewBuildCommand(log, bot),
 	})
 
 	return &Service{

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -106,7 +106,7 @@ func NewService(ctx context.Context, log *logrus.Logger, cfg *Config) (*Service,
 		checks.NewChecksCommand(log, bot),
 		mentions.NewMentionsCommand(log, bot),
 		cmdhive.NewHiveCommand(log, bot),
-		build.NewBuildCommand(log, bot),
+		build.NewBuildCommand(log, bot, cfg.GithubToken),
 	})
 
 	return &Service{


### PR DESCRIPTION
This commit introduces the `/build` slash command in panda-pulse, allowing users to trigger Docker image builds for various clients.

The following changes were made:

- Added `DefaultRepositories` and `DefaultBranches` maps in `pkg/clients/clients.go` to store the default source repositories and branches for each client.
- Created new files in `pkg/discord/cmd/build/`:
  - `command.go`: Defines the `BuildCommand` struct and its registration and handling logic.
  - `trigger.go`: Implements the `handleTrigger` function to process the build trigger subcommand, including validation, API calls, and response formatting.
  - `utils.go`: Contains utility functions for the build command, such as generating client choices for the command options.
- Modified `pkg/service/service.go` to register the new `BuildCommand` with the Discord bot.

The `/build` command supports the following options:

- `client`: The client to build (required).
- `repository`: The source repository to build from (optional, defaults to `DefaultRepositories`).
- `ref`: The branch, tag, or SHA to build from (optional, defaults to `DefaultBranches`).
- `docker_tag`: Override the target Docker tag (optional).

The command triggers a GitHub Actions workflow to build and push the Docker image.

<img width="860" alt="Screenshot 2025-04-10 at 10 46 10" src="https://github.com/user-attachments/assets/8415b478-c651-42f6-ad40-35bc76977189" />
<img width="868" alt="Screenshot 2025-04-10 at 10 46 23" src="https://github.com/user-attachments/assets/ba3c8597-dfd6-4cd4-b7a2-74d3b4fd9b51" />

