### PR TITLE
feat(config.go): require GITHUB_TOKEN environment variable

### DIFF
--- a/pkg/service/config.go
+++ b/pkg/service/config.go
@@ -84,5 +84,9 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("S3_BUCKET environment variable is required")
 	}
 
+	if c.GithubToken == "" {
+		return fmt.Errorf("GITHUB_TOKEN environment variable is required")
+	}
+
 	return nil
 }


### PR DESCRIPTION
This commit introduces a validation check for the GITHUB_TOKEN environment variable within the Config struct. The Validate method now returns an error if GITHUB_TOKEN is not set, ensuring that the application has the necessary credentials to interact with the GitHub API.