### PR TITLE
feat(discord): implement permission override for build trigger command

### DIFF
--- a/pkg/discord/bot.go
+++ b/pkg/discord/bot.go
@@ -188,6 +188,13 @@ func (b *DiscordBot) handleInteraction(s *discordgo.Session, i *discordgo.Intera
 	data := i.ApplicationCommandData()
 	for _, cmd := range b.commands {
 		if cmd.Name() == data.Name {
+			// Skip permission check for /build trigger as it has its own permission handling
+			if cmd.Name() == "build" && len(data.Options) > 0 && data.Options[0].Name == "trigger" {
+				cmd.Handle(s, i)
+
+				return
+			}
+
 			// Check permissions before executing command.
 			if !common.HasPermission(i.Member, s, i.GuildID, b.config.AsRoleConfig(), &data) {
 				if err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{

--- a/pkg/discord/cmd/build/command.go
+++ b/pkg/discord/cmd/build/command.go
@@ -95,10 +95,6 @@ func (c *BuildCommand) Handle(s *discordgo.Session, i *discordgo.InteractionCrea
 		return
 	}
 
-	c.log.Infof("i.Member: %v", i.Member)
-	c.log.Infof("i.Member.Roles: %v", i.Member.Roles)
-	c.log.Infof("c.bot.GetRoleConfig(): %v", c.bot.GetRoleConfig())
-
 	// Check permissions before executing command.
 	if !c.hasPermission(i.Member, s, i.GuildID, c.bot.GetRoleConfig()) {
 		if err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{

--- a/pkg/discord/cmd/build/command.go
+++ b/pkg/discord/cmd/build/command.go
@@ -95,6 +95,10 @@ func (c *BuildCommand) Handle(s *discordgo.Session, i *discordgo.InteractionCrea
 		return
 	}
 
+	c.log.Infof("i.Member: %v", i.Member)
+	c.log.Infof("i.Member.Roles: %v", i.Member.Roles)
+	c.log.Infof("c.bot.GetRoleConfig(): %v", c.bot.GetRoleConfig())
+
 	// Check permissions before executing command.
 	if !c.hasPermission(i.Member, s, i.GuildID, c.bot.GetRoleConfig()) {
 		if err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{

--- a/pkg/discord/cmd/build/trigger.go
+++ b/pkg/discord/cmd/build/trigger.go
@@ -151,9 +151,20 @@ func (c *BuildCommand) triggerWorkflow(clientName, repository, ref, dockerTag st
 		return "", fmt.Errorf("failed to marshal request body: %w", err)
 	}
 
+	// Map client names to their workflow names
+	workflowClientName := clientName
+
+	switch clientName {
+	case clients.CLNimbus:
+		workflowClientName = "nimbus-eth1"
+	case clients.ELNimbusel:
+		workflowClientName = "nimbus-eth2"
+	default:
+	}
+
 	req, err := http.NewRequest(
 		"POST",
-		fmt.Sprintf("https://api.github.com/repos/%s/actions/workflows/build-push-%s.yml/dispatches", DefaultRepository, clientName),
+		fmt.Sprintf("https://api.github.com/repos/%s/actions/workflows/build-push-%s.yml/dispatches", DefaultRepository, workflowClientName),
 		strings.NewReader(string(jsonBody)),
 	)
 	if err != nil {
@@ -177,5 +188,5 @@ func (c *BuildCommand) triggerWorkflow(clientName, repository, ref, dockerTag st
 		return "", fmt.Errorf("workflow trigger failed with status: %d", resp.StatusCode)
 	}
 
-	return fmt.Sprintf("https://github.com/%s/actions/workflows/build-push-%s.yml", DefaultRepository, clientName), nil
+	return fmt.Sprintf("https://github.com/%s/actions/workflows/build-push-%s.yml", DefaultRepository, workflowClientName), nil
 }

--- a/pkg/hive/hive.go
+++ b/pkg/hive/hive.go
@@ -186,7 +186,6 @@ func (h *hive) FetchTestResults(ctx context.Context, network string) ([]TestResu
 
 	// Fetch the listing.jsonl file which contains all test results
 	listingURL := fmt.Sprintf("%s/%s/listing.jsonl", h.baseURL, hiveNetwork)
-	fmt.Println("Fetching test results from:", listingURL)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, listingURL, nil)
 	if err != nil {


### PR DESCRIPTION
This commit introduces a change to bypass the default permission check for the `/build trigger` command in the Discord bot. This is necessary because the `/build trigger` command has its own permission handling logic.

Additionally, the commit includes a modification to map client names to their corresponding workflow names when triggering the build workflow. This ensures that the correct workflow is triggered for each client.