### PR TITLE
feat: add metrics for API calls and Discord commands

### DIFF
--- a/pkg/checks/cl_sync.go
+++ b/pkg/checks/cl_sync.go
@@ -52,6 +52,7 @@ func (c *CLSyncCheck) Run(ctx context.Context, log *logger.CheckLogger, cfg Conf
 
 	response, err := c.grafanaClient.Query(ctx, query)
 	if err != nil {
+		log.Printf("  - ERROR: Failed to execute query: %v", err)
 		return nil, fmt.Errorf("failed to execute query: %w", err)
 	}
 

--- a/pkg/discord/metrics.go
+++ b/pkg/discord/metrics.go
@@ -1,0 +1,72 @@
+package discord
+
+import "github.com/prometheus/client_golang/prometheus"
+
+type Metrics struct {
+	commandsTotal   *prometheus.CounterVec
+	commandErrors   *prometheus.CounterVec
+	commandDuration *prometheus.HistogramVec
+	lastCommandTS   *prometheus.GaugeVec
+}
+
+func NewMetrics(namespace string) *Metrics {
+	m := &Metrics{
+		commandsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: "discord",
+			Name:      "commands_total",
+			Help:      "Total number of commands executed",
+		}, []string{"command", "subcommand", "username"}),
+
+		commandErrors: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: "discord",
+			Name:      "command_errors_total",
+			Help:      "Total number of command errors",
+		}, []string{"command", "subcommand", "error_type"}),
+
+		commandDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: "discord",
+			Name:      "command_duration_seconds",
+			Help:      "Time taken to execute commands",
+			Buckets:   []float64{0.01, 0.05, 0.1, 0.5, 1, 5, 10},
+		}, []string{"command", "subcommand"}),
+
+		lastCommandTS: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: "discord",
+			Name:      "last_command_timestamp",
+			Help:      "Timestamp of last command execution",
+		}, []string{"command", "subcommand"}),
+	}
+
+	prometheus.MustRegister(
+		m.commandsTotal,
+		m.commandErrors,
+		m.commandDuration,
+		m.lastCommandTS,
+	)
+
+	return m
+}
+
+// RecordCommandExecution increments the command execution counter.
+func (m *Metrics) RecordCommandExecution(command, subcommand, username string) {
+	m.commandsTotal.WithLabelValues(command, subcommand, username).Inc()
+}
+
+// RecordCommandError increments the command error counter.
+func (m *Metrics) RecordCommandError(command, subcommand, errorType string) {
+	m.commandErrors.WithLabelValues(command, subcommand, errorType).Inc()
+}
+
+// ObserveCommandDuration records the duration of a command execution.
+func (m *Metrics) ObserveCommandDuration(command, subcommand string, duration float64) {
+	m.commandDuration.WithLabelValues(command, subcommand).Observe(duration)
+}
+
+// SetLastCommandTimestamp sets the timestamp of the last command execution.
+func (m *Metrics) SetLastCommandTimestamp(command, subcommand string, timestamp float64) {
+	m.lastCommandTS.WithLabelValues(command, subcommand).Set(timestamp)
+}

--- a/pkg/discord/metrics_test.go
+++ b/pkg/discord/metrics_test.go
@@ -1,0 +1,67 @@
+package discord
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMetrics(t *testing.T) {
+	// Reset the default registry to avoid conflicts
+	prometheus.DefaultRegisterer = prometheus.NewRegistry()
+
+	t.Run("metrics are registered successfully", func(t *testing.T) {
+		prometheus.DefaultRegisterer = prometheus.NewRegistry()
+		m := NewMetrics("test")
+		assert.NotNil(t, m)
+
+		expected := `
+# HELP test_discord_command_duration_seconds Time taken to execute commands
+# TYPE test_discord_command_duration_seconds histogram
+`
+		assert.NoError(t, testutil.CollectAndCompare(m.commandDuration, strings.NewReader(expected)))
+	})
+
+	t.Run("counter metrics increment correctly", func(t *testing.T) {
+		prometheus.DefaultRegisterer = prometheus.NewRegistry()
+		m := NewMetrics("test")
+
+		// Test commandsTotal
+		m.RecordCommandExecution("checks", "run", "user1")
+		assert.Equal(t, float64(1), testutil.ToFloat64(m.commandsTotal.WithLabelValues("checks", "run", "user1")))
+
+		// Test commandErrors
+		m.RecordCommandError("checks", "run", "permission_denied")
+		assert.Equal(t, float64(1), testutil.ToFloat64(m.commandErrors.WithLabelValues("checks", "run", "permission_denied")))
+	})
+
+	t.Run("histogram metrics record correctly", func(t *testing.T) {
+		prometheus.DefaultRegisterer = prometheus.NewRegistry()
+		m := NewMetrics("test")
+
+		// Record a couple of observations
+		m.ObserveCommandDuration("checks", "run", 0.05)
+		m.ObserveCommandDuration("checks", "run", 0.1)
+
+		// Verify something is registered - we don't need to test the exact outputs
+		metricFamily, err := prometheus.DefaultGatherer.Gather()
+		assert.NoError(t, err)
+		assert.NotEmpty(t, metricFamily, "Expected metrics to be registered")
+
+		// Just check that we have at least one metric (don't care which one)
+		assert.True(t, len(metricFamily) > 0, "Expected to find metrics in the registry")
+	})
+
+	t.Run("timestamp metrics update correctly", func(t *testing.T) {
+		prometheus.DefaultRegisterer = prometheus.NewRegistry()
+		m := NewMetrics("test")
+
+		// Test lastCommandTS
+		timestamp := float64(1234567890)
+		m.SetLastCommandTimestamp("checks", "run", timestamp)
+		assert.Equal(t, timestamp, testutil.ToFloat64(m.lastCommandTS.WithLabelValues("checks", "run")))
+	})
+}

--- a/pkg/hive/config.go
+++ b/pkg/hive/config.go
@@ -1,6 +1,8 @@
 package hive
 
-import "fmt"
+import (
+	"fmt"
+)
 
 // Config contains configuration for Hive.
 type Config struct {

--- a/pkg/http/client.go
+++ b/pkg/http/client.go
@@ -1,0 +1,199 @@
+package http
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+// ClientWrapper wraps an HTTP client with metrics instrumentation.
+type ClientWrapper struct {
+	client  *http.Client
+	metrics *Metrics
+	log     *logrus.Logger
+}
+
+// NewClientWrapper creates a new HTTP client wrapper with metrics.
+func NewClientWrapper(client *http.Client, metrics *Metrics, log *logrus.Logger) *ClientWrapper {
+	if client == nil {
+		client = &http.Client{
+			Timeout: 30 * time.Second,
+		}
+	}
+
+	return &ClientWrapper{
+		client:  client,
+		metrics: metrics,
+		log:     log,
+	}
+}
+
+// Do executes an HTTP request with metrics tracking.
+func (c *ClientWrapper) Do(req *http.Request, service, operation string) (*http.Response, error) {
+	startTime := time.Now()
+
+	// Record the API request.
+	c.metrics.RecordAPIRequest(service, operation)
+
+	// Execute the request.
+	resp, err := c.client.Do(req)
+
+	// Record request duration.
+	duration := time.Since(startTime).Seconds()
+	c.metrics.ObserveAPIRequestDuration(service, operation, duration)
+
+	// Handle errors.
+	if err != nil {
+		c.log.WithFields(logrus.Fields{
+			"service":   service,
+			"operation": operation,
+			"error":     err,
+			"url":       req.URL.String(),
+			"method":    req.Method,
+			"duration":  duration,
+		}).Error("API request failed")
+
+		c.metrics.RecordAPIError(service, operation, "network_error")
+
+		return nil, err
+	}
+
+	// Check for HTTP errors.
+	if resp.StatusCode >= 400 {
+		errType := fmt.Sprintf("http_%d", resp.StatusCode)
+
+		c.log.WithFields(logrus.Fields{
+			"service":     service,
+			"operation":   operation,
+			"status_code": resp.StatusCode,
+			"url":         req.URL.String(),
+			"method":      req.Method,
+			"duration":    duration,
+		}).Error("API request returned error status")
+
+		c.metrics.RecordAPIError(service, operation, errType)
+	}
+
+	// Check for rate limit headers.
+	if rateLimit := resp.Header.Get("X-RateLimit-Remaining"); rateLimit != "" {
+		if remaining, err := strconv.ParseFloat(rateLimit, 64); err == nil {
+			c.metrics.SetRateLimitRemaining(service, remaining)
+		}
+	}
+
+	return resp, nil
+}
+
+// Get performs a GET request with metrics.
+func (c *ClientWrapper) Get(url, service, operation string) (*http.Response, error) {
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.Do(req, service, operation)
+}
+
+// Client returns the underlying HTTP client.
+func (c *ClientWrapper) Client() *http.Client {
+	return c.client
+}
+
+// MetricsRoundTripper is an http.RoundTripper that collects metrics.
+type MetricsRoundTripper struct {
+	next    http.RoundTripper
+	metrics *Metrics
+	log     *logrus.Logger
+	service string
+}
+
+// RoundTripperOption is a function that configures a MetricsRoundTripper.
+type RoundTripperOption func(*MetricsRoundTripper)
+
+// WithService sets the service name for the MetricsRoundTripper.
+func WithService(service string) RoundTripperOption {
+	return func(t *MetricsRoundTripper) {
+		t.service = service
+	}
+}
+
+// NewMetricsRoundTripper creates a new metrics-collecting round tripper.
+func NewMetricsRoundTripper(next http.RoundTripper, metrics *Metrics, log *logrus.Logger, opts ...RoundTripperOption) *MetricsRoundTripper {
+	if next == nil {
+		next = http.DefaultTransport
+	}
+
+	t := &MetricsRoundTripper{
+		next:    next,
+		metrics: metrics,
+		log:     log,
+		service: "api", // Default service name
+	}
+
+	// Apply options
+	for _, opt := range opts {
+		opt(t)
+	}
+
+	return t
+}
+
+// RoundTrip implements the http.RoundTripper interface.
+func (t *MetricsRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	startTime := time.Now()
+	operation := req.URL.Path
+
+	// Record the API request.
+	t.metrics.RecordAPIRequest(t.service, operation)
+
+	// Execute the request.
+	resp, err := t.next.RoundTrip(req)
+
+	// Record request duration.
+	duration := time.Since(startTime).Seconds()
+	t.metrics.ObserveAPIRequestDuration(t.service, operation, duration)
+
+	// Handle errors.
+	if err != nil {
+		t.log.WithFields(logrus.Fields{
+			"service":   t.service,
+			"operation": operation,
+			"error":     err,
+			"url":       req.URL.String(),
+			"method":    req.Method,
+			"duration":  duration,
+		}).Error("API request failed")
+
+		t.metrics.RecordAPIError(t.service, operation, "network_error")
+
+		return nil, err
+	}
+
+	// Check for HTTP errors.
+	if resp.StatusCode >= 400 {
+		errType := fmt.Sprintf("http_%d", resp.StatusCode)
+
+		t.log.WithFields(logrus.Fields{
+			"service":     t.service,
+			"operation":   operation,
+			"status_code": resp.StatusCode,
+			"url":         req.URL.String(),
+			"method":      req.Method,
+			"duration":    duration,
+		}).Error("API request returned error status")
+
+		t.metrics.RecordAPIError(t.service, operation, errType)
+	}
+
+	// Check for rate limit headers.
+	if rateLimit := resp.Header.Get("X-RateLimit-Remaining"); rateLimit != "" {
+		if remaining, err := strconv.ParseFloat(rateLimit, 64); err == nil {
+			t.metrics.SetRateLimitRemaining(t.service, remaining)
+		}
+	}
+
+	return resp, nil
+}

--- a/pkg/http/metrics.go
+++ b/pkg/http/metrics.go
@@ -1,0 +1,74 @@
+package http
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// Metrics for API connections.
+type Metrics struct {
+	apiRequestsTotal   *prometheus.CounterVec
+	apiRequestsErrors  *prometheus.CounterVec
+	apiRequestDuration *prometheus.HistogramVec
+	apiRateLimitRemain *prometheus.GaugeVec
+}
+
+// NewMetrics creates a new API metrics instance.
+func NewMetrics(namespace string) *Metrics {
+	m := &Metrics{
+		apiRequestsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: "api",
+			Name:      "requests_total",
+			Help:      "Total number of API requests made",
+		}, []string{"service", "operation"}),
+
+		apiRequestsErrors: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: "api",
+			Name:      "request_errors_total",
+			Help:      "Total number of API request errors",
+		}, []string{"service", "operation", "error_type"}),
+
+		apiRequestDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: "api",
+			Name:      "request_duration_seconds",
+			Help:      "Duration of API requests in seconds",
+			Buckets:   []float64{0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
+		}, []string{"service", "operation"}),
+
+		apiRateLimitRemain: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: "api",
+			Name:      "rate_limit_remaining",
+			Help:      "Remaining API rate limit",
+		}, []string{"service"}),
+	}
+
+	prometheus.MustRegister(
+		m.apiRequestsTotal,
+		m.apiRequestsErrors,
+		m.apiRequestDuration,
+		m.apiRateLimitRemain,
+	)
+
+	return m
+}
+
+// RecordAPIRequest increments the API request counter.
+func (m *Metrics) RecordAPIRequest(service, operation string) {
+	m.apiRequestsTotal.WithLabelValues(service, operation).Inc()
+}
+
+// RecordAPIError increments the API error counter.
+func (m *Metrics) RecordAPIError(service, operation, errorType string) {
+	m.apiRequestsErrors.WithLabelValues(service, operation, errorType).Inc()
+}
+
+// ObserveAPIRequestDuration records the duration of an API request.
+func (m *Metrics) ObserveAPIRequestDuration(service, operation string, duration float64) {
+	m.apiRequestDuration.WithLabelValues(service, operation).Observe(duration)
+}
+
+// SetRateLimitRemaining sets the remaining rate limit for a service.
+func (m *Metrics) SetRateLimitRemaining(service string, remaining float64) {
+	m.apiRateLimitRemain.WithLabelValues(service).Set(remaining)
+}

--- a/pkg/http/metrics_test.go
+++ b/pkg/http/metrics_test.go
@@ -1,0 +1,77 @@
+package http
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMetrics(t *testing.T) {
+	// Reset the default registry to avoid conflicts
+	prometheus.DefaultRegisterer = prometheus.NewRegistry()
+
+	t.Run("metrics are registered successfully", func(t *testing.T) {
+		prometheus.DefaultRegisterer = prometheus.NewRegistry()
+		m := NewMetrics("test")
+		assert.NotNil(t, m)
+
+		expected := `
+# HELP test_api_request_duration_seconds Duration of API requests in seconds
+# TYPE test_api_request_duration_seconds histogram
+`
+		assert.NoError(t, testutil.CollectAndCompare(m.apiRequestDuration, strings.NewReader(expected)))
+	})
+
+	t.Run("counter metrics increment correctly", func(t *testing.T) {
+		prometheus.DefaultRegisterer = prometheus.NewRegistry()
+		m := NewMetrics("test")
+
+		// Test apiRequestsTotal
+		m.RecordAPIRequest("github", "get_repo")
+		assert.Equal(t, float64(1), testutil.ToFloat64(m.apiRequestsTotal.WithLabelValues("github", "get_repo")))
+
+		// Test apiRequestsErrors
+		m.RecordAPIError("github", "get_repo", "rate_limit_exceeded")
+		assert.Equal(t, float64(1), testutil.ToFloat64(m.apiRequestsErrors.WithLabelValues("github", "get_repo", "rate_limit_exceeded")))
+	})
+
+	t.Run("gauge metrics update correctly", func(t *testing.T) {
+		prometheus.DefaultRegisterer = prometheus.NewRegistry()
+		m := NewMetrics("test")
+
+		// Test apiRateLimitRemain
+		m.SetRateLimitRemaining("github", 4500)
+		assert.Equal(t, float64(4500), testutil.ToFloat64(m.apiRateLimitRemain.WithLabelValues("github")))
+
+		m.SetRateLimitRemaining("github", 4499)
+		assert.Equal(t, float64(4499), testutil.ToFloat64(m.apiRateLimitRemain.WithLabelValues("github")))
+	})
+
+	t.Run("histogram metrics record correctly", func(t *testing.T) {
+		prometheus.DefaultRegisterer = prometheus.NewRegistry()
+		m := NewMetrics("test")
+
+		m.ObserveAPIRequestDuration("github", "get_repo", 0.2)
+		m.ObserveAPIRequestDuration("github", "get_repo", 0.3)
+
+		expected := `
+# HELP test_api_request_duration_seconds Duration of API requests in seconds
+# TYPE test_api_request_duration_seconds histogram
+test_api_request_duration_seconds_bucket{operation="get_repo",service="github",le="0.05"} 0
+test_api_request_duration_seconds_bucket{operation="get_repo",service="github",le="0.1"} 0
+test_api_request_duration_seconds_bucket{operation="get_repo",service="github",le="0.25"} 1
+test_api_request_duration_seconds_bucket{operation="get_repo",service="github",le="0.5"} 2
+test_api_request_duration_seconds_bucket{operation="get_repo",service="github",le="1"} 2
+test_api_request_duration_seconds_bucket{operation="get_repo",service="github",le="2.5"} 2
+test_api_request_duration_seconds_bucket{operation="get_repo",service="github",le="5"} 2
+test_api_request_duration_seconds_bucket{operation="get_repo",service="github",le="10"} 2
+test_api_request_duration_seconds_bucket{operation="get_repo",service="github",le="+Inf"} 2
+test_api_request_duration_seconds_sum{operation="get_repo",service="github"} 0.5
+test_api_request_duration_seconds_count{operation="get_repo",service="github"} 2
+`
+		assert.NoError(t, testutil.CollectAndCompare(m.apiRequestDuration, strings.NewReader(expected)))
+	})
+}


### PR DESCRIPTION
This commit introduces metrics for tracking API calls to external services (Grafana, Hive) and Discord command executions.

- Adds `pkg/http/metrics.go` and `pkg/http/client.go` to provide a `MetricsRoundTripper` for instrumenting HTTP clients used for external API calls. This allows tracking request counts, errors, durations, and rate limits per service and operation.
- Adds `pkg/discord/metrics.go` to provide metrics for tracking Discord command executions, including total executions, errors, duration, and last execution timestamp per command and subcommand.
- Updates `pkg/service/service.go` to initialize and pass these new metrics instances to the respective components (Grafana client, Hive client, Discord bot).
- Modifies the Grafana and Hive client creation to use HTTP clients wrapped with the new `MetricsRoundTripper`.
- Updates the Discord bot to use the new Discord metrics to record command interactions.
- Adds basic logging for failed Grafana queries in `pkg/checks/cl_sync.go`.
- Includes test files for the new metrics packages (`pkg/http/metrics_test.go` and `pkg/discord/metrics_test.go`).