### PR TITLE
feat(discord): add support for building tools and clients

### DIFF
--- a/pkg/clients/clients.go
+++ b/pkg/clients/clients.go
@@ -105,6 +105,15 @@ var (
 		ELErigon:     "main",
 		ELEthereumJS: "master",
 	}
+	// ClientsWithBuildArgs is a map of clients that support build arguments and their default values.
+	ClientsWithBuildArgs = map[string]struct {
+		BuildArgs    string
+		HasBuildArgs bool
+	}{
+		CLLighthouse: {
+			HasBuildArgs: true,
+		},
+	}
 )
 
 // IsCLClient returns true if the client is a consensus client.
@@ -168,4 +177,22 @@ func GetClientLogo(client string) string {
 // IsPreProductionClient returns true if the client is considered pre-production.
 func IsPreProductionClient(client string) bool {
 	return PreProductionClients[client]
+}
+
+// ClientSupportsBuildArgs returns whether the given client supports build arguments.
+func ClientSupportsBuildArgs(client string) bool {
+	if clientInfo, exists := ClientsWithBuildArgs[client]; exists {
+		return clientInfo.HasBuildArgs
+	}
+
+	return false
+}
+
+// GetClientDefaultBuildArgs returns the default build arguments for a client, if any.
+func GetClientDefaultBuildArgs(client string) string {
+	if clientInfo, exists := ClientsWithBuildArgs[client]; exists && clientInfo.BuildArgs != "" {
+		return clientInfo.BuildArgs
+	}
+
+	return ""
 }

--- a/pkg/discord/cmd/build/trigger.go
+++ b/pkg/discord/cmd/build/trigger.go
@@ -16,30 +16,61 @@ const (
 	buildEmbedColor = 0x7289DA
 )
 
-// handleTrigger handles the trigger subcommand.
-func (c *BuildCommand) handleTrigger(s *discordgo.Session, i *discordgo.InteractionCreate, option *discordgo.ApplicationCommandInteractionDataOption) error {
+// handleBuild handles the build subcommands (client-cl, client-el, tool).
+//
+//nolint:gocyclo // Not that bad, switch statement throwing it.
+func (c *BuildCommand) handleBuild(s *discordgo.Session, i *discordgo.InteractionCreate, option *discordgo.ApplicationCommandInteractionDataOption) error {
+	// Determine what type of build this is.
+	var (
+		targetName, targetDisplayName string
+		isClient                      bool
+	)
+
+	switch option.Name {
+	case "client-cl", "client-el":
+		isClient = true
+
+		for _, opt := range option.Options {
+			if opt.Name == "client" {
+				targetName = opt.StringValue()
+				targetDisplayName = targetName
+
+				break
+			}
+		}
+	case "tool":
+		isClient = false
+
+		for _, opt := range option.Options {
+			if opt.Name == "workflow" {
+				targetName = opt.StringValue()
+				if workflow, exists := AdditionalWorkflows[targetName]; exists {
+					targetDisplayName = workflow.Name
+				} else {
+					targetDisplayName = targetName
+				}
+
+				break
+			}
+		}
+	}
+
 	// Send immediate response, discord requires an ACK with 3s, sometimes triggering
 	// the build can blow out, and then things will fall apart.
 	if err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseChannelMessageWithSource,
 		Data: &discordgo.InteractionResponseData{
-			Content: fmt.Sprintf("🔄 Triggering build for **%s**...", option.Options[0].StringValue()),
+			Content: fmt.Sprintf("🔄 Triggering build for **%s**...", targetDisplayName),
 			Flags:   discordgo.MessageFlagsEphemeral,
 		},
 	}); err != nil {
 		return fmt.Errorf("failed to send initial response: %w", err)
 	}
 
-	// Get the client from the options.
-	var (
-		client = option.Options[0].StringValue()
-		err    error
-	)
-
 	// Get optional parameters.
-	var repository, ref, dockerTag string
+	var repository, ref, dockerTag, buildArgs string
 
-	for _, opt := range option.Options[1:] {
+	for _, opt := range option.Options {
 		switch opt.Name {
 		case "repository":
 			repository = opt.StringValue()
@@ -47,33 +78,82 @@ func (c *BuildCommand) handleTrigger(s *discordgo.Session, i *discordgo.Interact
 			ref = opt.StringValue()
 		case "docker_tag":
 			dockerTag = opt.StringValue()
+		case "build_args":
+			buildArgs = opt.StringValue()
 		}
 	}
 
 	// Use defaults if not provided.
 	if repository == "" {
-		repository = clients.DefaultRepositories[client]
+		if isClient {
+			if repo, exists := clients.DefaultRepositories[targetName]; exists {
+				repository = repo
+			} else {
+				// For unknown clients, repository is required.
+				if _, interactionErr := s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
+					Content: stringPtr(fmt.Sprintf("❌ Repository is required for **%s**", targetDisplayName)),
+				}); interactionErr != nil {
+					return fmt.Errorf("failed to edit response: %w", interactionErr)
+				}
+
+				return nil
+			}
+		} else {
+			// For tools, get from AdditionalWorkflows.
+			if workflow, exists := AdditionalWorkflows[targetName]; exists {
+				repository = workflow.Repository
+			} else {
+				// This should never happen with the dropdown selection.
+				if _, interactionErr := s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
+					Content: stringPtr(fmt.Sprintf("❌ Unknown tool workflow: **%s**", targetName)),
+				}); interactionErr != nil {
+					return fmt.Errorf("failed to edit response: %w", interactionErr)
+				}
+
+				return nil
+			}
+		}
 	}
 
 	if ref == "" {
-		ref = clients.DefaultBranches[client]
+		if isClient {
+			if branch, exists := clients.DefaultBranches[targetName]; exists {
+				ref = branch
+			} else {
+				// For unknown clients, default to main.
+				ref = "main"
+			}
+		} else {
+			// For tools, get from AdditionalWorkflows.
+			if workflow, exists := AdditionalWorkflows[targetName]; exists {
+				ref = workflow.Branch
+			} else {
+				// This should never happen with the dropdown selection.
+				ref = "main"
+			}
+		}
+	}
+
+	// Use default build args if provided and user didn't specify any.
+	if buildArgs == "" && HasBuildArgs(targetName) {
+		buildArgs = GetDefaultBuildArgs(targetName)
 	}
 
 	// Trigger the workflow.
-	workflowURL, err := c.triggerWorkflow(client, repository, ref, dockerTag)
+	workflowURL, err := c.triggerWorkflow(targetName, repository, ref, dockerTag, buildArgs)
 	if err != nil {
 		if _, interactionErr := s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
-			Content: stringPtr(fmt.Sprintf("❌ Failed to trigger build for **%s**: %s", client, err)),
+			Content: stringPtr(fmt.Sprintf("❌ Failed to trigger build for **%s**: %s", targetDisplayName, err)),
 		}); interactionErr != nil {
 			return fmt.Errorf("failed to edit response with error: %w (original error: %s)", interactionErr, err)
 		}
 
-		return nil // Already handled error by editing message
+		return nil // Already handled error by editing message.
 	}
 
 	// Create success embed.
 	embed := &discordgo.MessageEmbed{
-		Title: fmt.Sprintf("🏗️ Build Triggered: %s", client),
+		Title: fmt.Sprintf("🏗️ Build Triggered: %s", targetDisplayName),
 		Color: buildEmbedColor,
 		Fields: []*discordgo.MessageEmbedField{
 			{
@@ -105,10 +185,26 @@ func (c *BuildCommand) handleTrigger(s *discordgo.Session, i *discordgo.Interact
 		})
 	}
 
-	// Add client logo if available.
-	if logo := clients.GetClientLogo(client); logo != "" {
+	// Add build args if specified.
+	if buildArgs != "" {
+		embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
+			Name:   "Build Args",
+			Value:  fmt.Sprintf("`%s`", buildArgs),
+			Inline: true,
+		})
+	}
+
+	// Add thumbnail.
+	if isClient && (clients.IsELClient(targetName) || clients.IsCLClient(targetName)) {
+		if logo := clients.GetClientLogo(targetName); logo != "" {
+			embed.Thumbnail = &discordgo.MessageEmbedThumbnail{
+				URL: logo,
+			}
+		}
+	} else {
+		// Default logo for non-client workflows.
 		embed.Thumbnail = &discordgo.MessageEmbedThumbnail{
-			URL: logo,
+			URL: "https://pbs.twimg.com/profile_images/1772523356123959296/e9mkwqVp_400x400.jpg",
 		}
 	}
 
@@ -121,16 +217,18 @@ func (c *BuildCommand) handleTrigger(s *discordgo.Session, i *discordgo.Interact
 	}
 
 	c.log.WithFields(logrus.Fields{
+		"workflow":   targetName,
 		"repository": repository,
 		"ref":        ref,
 		"docker_tag": dockerTag,
-	}).Info("Build triggered successfully")
+		"build_args": buildArgs,
+	}).Info("Build triggered")
 
 	return nil
 }
 
-// triggerWorkflow triggers the GitHub workflow for the given client.
-func (c *BuildCommand) triggerWorkflow(clientName, repository, ref, dockerTag string) (string, error) {
+// triggerWorkflow triggers the GitHub workflow for the given build target.
+func (c *BuildCommand) triggerWorkflow(buildTarget, repository, ref, dockerTag string, buildArgs string) (string, error) {
 	// Prepare the workflow inputs.
 	inputs := map[string]interface{}{
 		"repository": repository,
@@ -139,6 +237,10 @@ func (c *BuildCommand) triggerWorkflow(clientName, repository, ref, dockerTag st
 
 	if dockerTag != "" {
 		inputs["docker_tag"] = dockerTag
+	}
+
+	if buildArgs != "" {
+		inputs["build_args"] = buildArgs
 	}
 
 	body := map[string]interface{}{
@@ -151,22 +253,23 @@ func (c *BuildCommand) triggerWorkflow(clientName, repository, ref, dockerTag st
 		return "", fmt.Errorf("failed to marshal request body: %w", err)
 	}
 
-	// Map client names to their workflow names
-	workflowClientName := clientName
+	// Determine the workflow path based on the build target
+	workflowName := buildTarget
 
-	switch clientName {
+	// Special case mapping for clients with different repo/workflow names
+	switch buildTarget {
 	case clients.CLNimbus:
 		// See: https://github.com/status-im/nimbus-eth2
-		workflowClientName = "nimbus-eth2"
+		workflowName = "nimbus-eth2"
 	case clients.ELNimbusel:
 		// See: https://github.com/status-im/nimbus-eth1
-		workflowClientName = "nimbus-eth1"
+		workflowName = "nimbus-eth1"
 	default:
 	}
 
 	req, err := http.NewRequest(
 		"POST",
-		fmt.Sprintf("https://api.github.com/repos/%s/actions/workflows/build-push-%s.yml/dispatches", DefaultRepository, workflowClientName),
+		fmt.Sprintf("https://api.github.com/repos/%s/actions/workflows/build-push-%s.yml/dispatches", DefaultRepository, workflowName),
 		strings.NewReader(string(jsonBody)),
 	)
 	if err != nil {
@@ -190,5 +293,5 @@ func (c *BuildCommand) triggerWorkflow(clientName, repository, ref, dockerTag st
 		return "", fmt.Errorf("workflow trigger failed with status: %d", resp.StatusCode)
 	}
 
-	return fmt.Sprintf("https://github.com/%s/actions/workflows/build-push-%s.yml", DefaultRepository, workflowClientName), nil
+	return fmt.Sprintf("https://github.com/%s/actions/workflows/build-push-%s.yml", DefaultRepository, workflowName), nil
 }


### PR DESCRIPTION
refactor(discord): split build command into subcommands for CL clients, EL clients, and tools
feat(discord): add support for build arguments in the build command
feat(discord): add default build arguments for clients and tools that support them
refactor(discord): rename handleTrigger to handleBuild to reflect broader functionality
refactor(discord): rename getClientChoices to getCLClientChoices and add getELClientChoices and getToolsChoices