### PR TITLE
refactor(app): source client data from cartographoor

### DIFF
--- a/pkg/analyzer/analyzer_test.go
+++ b/pkg/analyzer/analyzer_test.go
@@ -1,25 +1,31 @@
 package analyzer
 
 import (
+	"context"
 	"testing"
 
+	"github.com/ethpandaops/panda-pulse/pkg/clients"
 	"github.com/ethpandaops/panda-pulse/pkg/logger"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestAnalyzer_RootCauseDetection(t *testing.T) {
+	cs, _ := clients.NewService(context.Background(), clients.ServiceConfig{})
+
 	tests := []struct {
 		name            string
 		targetClient    string
 		clientType      ClientType
+		clientsService  *clients.Service
 		nodes           map[string]bool // map[nodeName]isHealthy
 		wantRootCause   []string
 		wantUnexplained []string
 	}{
 		{
-			name:         "all healthy nodes",
-			targetClient: "lighthouse",
-			clientType:   ClientTypeCL,
+			name:           "all healthy nodes",
+			targetClient:   "lighthouse",
+			clientType:     ClientTypeCL,
+			clientsService: cs,
 			nodes: map[string]bool{
 				"lighthouse-geth-1":       true,
 				"lighthouse-besu-1":       true,
@@ -29,9 +35,10 @@ func TestAnalyzer_RootCauseDetection(t *testing.T) {
 			wantUnexplained: []string{},
 		},
 		{
-			name:         "unexplained issue - single failure pair",
-			targetClient: "lighthouse",
-			clientType:   ClientTypeCL,
+			name:           "unexplained issue - single failure pair",
+			targetClient:   "lighthouse",
+			clientType:     ClientTypeCL,
+			clientsService: cs,
 			nodes: map[string]bool{
 				"lighthouse-erigon-1": false, // Only this lighthouse+erigon pair is failing.
 				"lighthouse-geth-1":   true,  // Other lighthouse pairs are healthy.
@@ -43,9 +50,10 @@ func TestAnalyzer_RootCauseDetection(t *testing.T) {
 			wantUnexplained: []string{"lighthouse-erigon-1"},
 		},
 		{
-			name:         "clear root cause - EL client failing with many CL clients",
-			targetClient: "ethereumjs",
-			clientType:   ClientTypeEL,
+			name:           "clear root cause - EL client failing with many CL clients",
+			targetClient:   "ethereumjs",
+			clientType:     ClientTypeEL,
+			clientsService: cs,
 			nodes: map[string]bool{
 				"lighthouse-ethereumjs-1": false,
 				"teku-ethereumjs-1":       false,
@@ -62,9 +70,10 @@ func TestAnalyzer_RootCauseDetection(t *testing.T) {
 		// This tests when we have multiple instances of the same client pair (prysm-geth-N).
 		// Some failing, some healthy, each failing instance should be listed as unexplained.
 		{
-			name:         "multiple node instances - same client pair",
-			targetClient: "prysm",
-			clientType:   ClientTypeCL,
+			name:           "multiple node instances - same client pair",
+			targetClient:   "prysm",
+			clientType:     ClientTypeCL,
+			clientsService: cs,
 			nodes: map[string]bool{
 				"prysm-geth-1": false,
 				"prysm-geth-2": false,
@@ -82,9 +91,10 @@ func TestAnalyzer_RootCauseDetection(t *testing.T) {
 			},
 		},
 		{
-			name:         "clear root cause - CL client failing with many EL clients",
-			targetClient: "prysm",
-			clientType:   ClientTypeCL,
+			name:           "clear root cause - CL client failing with many EL clients",
+			targetClient:   "prysm",
+			clientType:     ClientTypeCL,
+			clientsService: cs,
 			nodes: map[string]bool{
 				"prysm-erigon-1":     false,
 				"prysm-geth-1":       false,
@@ -99,9 +109,10 @@ func TestAnalyzer_RootCauseDetection(t *testing.T) {
 			wantUnexplained: []string{},
 		},
 		{
-			name:         "false positive - client only failing with known root causes",
-			targetClient: "lighthouse",
-			clientType:   ClientTypeCL,
+			name:           "false positive - client only failing with known root causes",
+			targetClient:   "lighthouse",
+			clientType:     ClientTypeCL,
+			clientsService: cs,
 			nodes: map[string]bool{
 				// ethereumjs + nethermind are root causes (failing with many CL clients).
 				"lighthouse-ethereumjs-1": false,
@@ -120,9 +131,10 @@ func TestAnalyzer_RootCauseDetection(t *testing.T) {
 			wantUnexplained: []string{},
 		},
 		{
-			name:         "mixed health status - some nodes healthy, some failing",
-			targetClient: "ethereumjs",
-			clientType:   ClientTypeEL,
+			name:           "mixed health status - some nodes healthy, some failing",
+			targetClient:   "ethereumjs",
+			clientType:     ClientTypeEL,
+			clientsService: cs,
 			nodes: map[string]bool{
 				"lighthouse-ethereumjs-1": false,
 				"teku-ethereumjs-1":       false,
@@ -137,9 +149,10 @@ func TestAnalyzer_RootCauseDetection(t *testing.T) {
 			wantUnexplained: []string{},
 		},
 		{
-			name:         "borderline case - client failing with exactly MinFailuresForRootCause peers",
-			targetClient: "reth",
-			clientType:   ClientTypeEL,
+			name:           "borderline case - client failing with exactly MinFailuresForRootCause peers",
+			targetClient:   "reth",
+			clientType:     ClientTypeEL,
+			clientsService: cs,
 			nodes: map[string]bool{
 				// Exactly MinFailuresForRootCause (2) failures.
 				"lighthouse-reth-1": false,
@@ -152,9 +165,10 @@ func TestAnalyzer_RootCauseDetection(t *testing.T) {
 			wantUnexplained: []string{},
 		},
 		{
-			name:         "below threshold - client failing with less than MinFailuresForRootCause peers",
-			targetClient: "reth",
-			clientType:   ClientTypeEL,
+			name:           "below threshold - client failing with less than MinFailuresForRootCause peers",
+			targetClient:   "reth",
+			clientType:     ClientTypeEL,
+			clientsService: cs,
 			nodes: map[string]bool{
 				// Only one failure, below MinFailuresForRootCause (2).
 				"lighthouse-reth-1": false,
@@ -167,9 +181,10 @@ func TestAnalyzer_RootCauseDetection(t *testing.T) {
 			wantUnexplained: []string{"lighthouse-reth-1"},
 		},
 		{
-			name:         "secondary root cause - client failing with non-root-cause peers",
-			targetClient: "lighthouse",
-			clientType:   ClientTypeCL,
+			name:           "secondary root cause - client failing with non-root-cause peers",
+			targetClient:   "lighthouse",
+			clientType:     ClientTypeCL,
+			clientsService: cs,
 			nodes: map[string]bool{
 				// lighthouse failing with multiple non-root-cause EL clients.
 				"lighthouse-geth-1":       false,
@@ -187,9 +202,10 @@ func TestAnalyzer_RootCauseDetection(t *testing.T) {
 			wantUnexplained: []string{},
 		},
 		{
-			name:         "major root cause overrides - client failing with many peers including root causes",
-			targetClient: "lighthouse",
-			clientType:   ClientTypeCL,
+			name:           "major root cause overrides - client failing with many peers including root causes",
+			targetClient:   "lighthouse",
+			clientType:     ClientTypeCL,
+			clientsService: cs,
 			nodes: map[string]bool{
 				// lighthouse failing with many peers (>4).
 				"lighthouse-geth-1":       false,
@@ -207,9 +223,10 @@ func TestAnalyzer_RootCauseDetection(t *testing.T) {
 			wantUnexplained: []string{},
 		},
 		{
-			name:         "secondary root cause - EL client failing with non-root-cause peers",
-			targetClient: "besu",
-			clientType:   ClientTypeEL,
+			name:           "secondary root cause - EL client failing with non-root-cause peers",
+			targetClient:   "besu",
+			clientType:     ClientTypeEL,
+			clientsService: cs,
 			nodes: map[string]bool{
 				// besu failing with multiple non-root-cause CL clients
 				"lighthouse-besu-1": false,
@@ -227,9 +244,10 @@ func TestAnalyzer_RootCauseDetection(t *testing.T) {
 			wantUnexplained: []string{}, // These won't show up as unexplained from besu's perspective.
 		},
 		{
-			name:         "secondary root cause - CL client failing with non-root-cause peers",
-			targetClient: "teku",
-			clientType:   ClientTypeCL,
+			name:           "secondary root cause - CL client failing with non-root-cause peers",
+			targetClient:   "teku",
+			clientType:     ClientTypeCL,
+			clientsService: cs,
 			nodes: map[string]bool{
 				// teku failing with multiple non-root-cause EL clients.
 				"teku-geth-1":       false,
@@ -247,9 +265,10 @@ func TestAnalyzer_RootCauseDetection(t *testing.T) {
 			wantUnexplained: []string{},
 		},
 		{
-			name:         "unexplained issues - CL clients with single failures",
-			targetClient: "grandine",
-			clientType:   ClientTypeCL,
+			name:           "unexplained issues - CL clients with single failures",
+			targetClient:   "grandine",
+			clientType:     ClientTypeCL,
+			clientsService: cs,
 			nodes: map[string]bool{
 				// Single failure with besu
 				"grandine-besu-1": false,
@@ -261,9 +280,10 @@ func TestAnalyzer_RootCauseDetection(t *testing.T) {
 			wantUnexplained: []string{"grandine-besu-1"},
 		},
 		{
-			name:         "pre-production client exception - not removed as false positive",
-			targetClient: "lighthouse",
-			clientType:   ClientTypeCL,
+			name:           "pre-production client exception - not removed as false positive",
+			targetClient:   "lighthouse",
+			clientType:     ClientTypeCL,
+			clientsService: cs,
 			nodes: map[string]bool{
 				// ethereumjs is already in PreProductionClients map
 				// Failing with exactly MinFailuresForRootCause peers (which happen to be major root causes)
@@ -288,9 +308,10 @@ func TestAnalyzer_RootCauseDetection(t *testing.T) {
 			wantUnexplained: []string{},
 		},
 		{
-			name:         "pre-production client skipped in unexplained issues",
-			targetClient: "lighthouse",
-			clientType:   ClientTypeCL,
+			name:           "pre-production client skipped in unexplained issues",
+			targetClient:   "lighthouse",
+			clientType:     ClientTypeCL,
+			clientsService: cs,
 			nodes: map[string]bool{
 				// A failing node with pre-production client (ethereumjs)
 				"lighthouse-ethereumjs-1": false,
@@ -309,7 +330,7 @@ func TestAnalyzer_RootCauseDetection(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			log := logger.NewCheckLogger("id")
-			a := NewAnalyzer(log, tt.targetClient, tt.clientType)
+			a := NewAnalyzer(log, tt.targetClient, tt.clientType, tt.clientsService)
 
 			for nodeName, isHealthy := range tt.nodes {
 				a.AddNodeStatus(nodeName, isHealthy)

--- a/pkg/checks/checks.go
+++ b/pkg/checks/checks.go
@@ -70,16 +70,17 @@ type Runner interface {
 
 // defaultRunner is a default implementation of the Runner interface.
 type defaultRunner struct {
-	id       string
-	log      *logger.CheckLogger
-	cfg      Config
-	checks   []Check
-	results  []*Result
-	analysis *analyzer.AnalysisResult
+	id             string
+	log            *logger.CheckLogger
+	cfg            Config
+	checks         []Check
+	results        []*Result
+	analysis       *analyzer.AnalysisResult
+	clientsService *clients.Service
 }
 
 // NewDefaultRunner creates a new default check runner.
-func NewDefaultRunner(cfg Config) Runner {
+func NewDefaultRunner(cfg Config, clientsService *clients.Service) Runner {
 	// Give the runner a unique ID, so we can identify things easily.
 	id := generateCheckID()
 
@@ -89,10 +90,11 @@ func NewDefaultRunner(cfg Config) Runner {
 	log := logger.NewCheckLogger(id)
 
 	return &defaultRunner{
-		id:     id,
-		log:    log,
-		cfg:    cfg,
-		checks: make([]Check, 0),
+		id:             id,
+		log:            log,
+		cfg:            cfg,
+		checks:         make([]Check, 0),
+		clientsService: clientsService,
 	}
 }
 
@@ -131,12 +133,12 @@ func (r *defaultRunner) RunChecks(ctx context.Context) error {
 	)
 
 	if r.cfg.ConsensusNode != "" {
-		a = analyzer.NewAnalyzer(r.log, r.cfg.ConsensusNode, analyzer.ClientTypeCL)
+		a = analyzer.NewAnalyzer(r.log, r.cfg.ConsensusNode, analyzer.ClientTypeCL, r.clientsService)
 		client = r.cfg.ConsensusNode
 	}
 
 	if r.cfg.ExecutionNode != "" {
-		a = analyzer.NewAnalyzer(r.log, r.cfg.ExecutionNode, analyzer.ClientTypeEL)
+		a = analyzer.NewAnalyzer(r.log, r.cfg.ExecutionNode, analyzer.ClientTypeEL, r.clientsService)
 		client = r.cfg.ExecutionNode
 	}
 

--- a/pkg/clients/clients.go
+++ b/pkg/clients/clients.go
@@ -1,7 +1,5 @@
 package clients
 
-import "strings"
-
 // ClientType represents the type of client.
 type ClientType string
 
@@ -24,42 +22,22 @@ func (c ClientType) String() string {
 	}
 }
 
-// Define a list of known clients.
-const (
-	CLLighthouse = "lighthouse"
-	CLPrysm      = "prysm"
-	CLLodestar   = "lodestar"
-	CLNimbus     = "nimbus"
-	CLTeku       = "teku"
-	CLGrandine   = "grandine"
-	ELNethermind = "nethermind"
-	ELNimbusel   = "nimbusel"
-	ELBesu       = "besu"
-	ELGeth       = "geth"
-	ELReth       = "reth"
-	ELErigon     = "erigon"
-	ELEthereumJS = "ethereumjs"
-)
-
 var (
-	// Buckets of known clients.
-	CLClients = []string{CLLighthouse, CLPrysm, CLLodestar, CLNimbus, CLTeku, CLGrandine}
-	ELClients = []string{ELNethermind, ELNimbusel, ELBesu, ELGeth, ELReth, ELErigon, ELEthereumJS}
 	// TeamRoles maps clients to their respective team's Discord role.
 	TeamRoles = map[string]string{
-		CLLighthouse: "sigmaprime",
-		CLPrysm:      "prysmatic",
-		CLLodestar:   "chainsafe",
-		CLNimbus:     "nimbus",
-		CLTeku:       "teku",
-		CLGrandine:   "grandine",
-		ELNethermind: "nethermind",
-		ELNimbusel:   "nimbus",
-		ELBesu:       "besu",
-		ELGeth:       "geth",
-		ELReth:       "reth",
-		ELErigon:     "erigon",
-		ELEthereumJS: "ethereumjs",
+		"lighthouse": "sigmaprime",
+		"prysm":      "prysmatic",
+		"lodestar":   "chainsafe",
+		"nimbus":     "nimbus",
+		"teku":       "teku",
+		"grandine":   "grandine",
+		"nethermind": "nethermind",
+		"nimbusel":   "nimbus",
+		"besu":       "besu",
+		"geth":       "geth",
+		"reth":       "reth",
+		"erigon":     "erigon",
+		"ethereumjs": "ethereumjs",
 	}
 	// AdminRoles maps admin roles to their respective Discord role.
 	AdminRoles = map[string]string{
@@ -69,130 +47,17 @@ var (
 	}
 	// Pre-production clients.
 	PreProductionClients = map[string]bool{
-		ELEthereumJS: true,
-		ELNimbusel:   true,
+		"ethereumjs": true,
+		"nimbusel":   true,
 		"erigonTwo":  true, // Not in standard client list but tracked for pre-production.
-	}
-	// DefaultRepositories maps clients to their default source repositories.
-	DefaultRepositories = map[string]string{
-		CLLighthouse: "sigp/lighthouse",
-		CLPrysm:      "OffchainLabs/prysm",
-		CLLodestar:   "chainsafe/lodestar",
-		CLNimbus:     "status-im/nimbus-eth2",
-		CLTeku:       "ConsenSys/teku",
-		CLGrandine:   "grandinetech/grandine",
-		ELNethermind: "NethermindEth/nethermind",
-		ELNimbusel:   "status-im/nimbus-eth1",
-		ELBesu:       "hyperledger/besu",
-		ELGeth:       "ethereum/go-ethereum",
-		ELReth:       "paradigmxyz/reth",
-		ELErigon:     "erigontech/erigon",
-		ELEthereumJS: "ethereumjs/ethereumjs-monorepo",
-	}
-	// DefaultBranches maps clients to their default branches.
-	DefaultBranches = map[string]string{
-		CLLighthouse: "stable",
-		CLPrysm:      "develop",
-		CLLodestar:   "unstable",
-		CLNimbus:     "stable",
-		CLTeku:       "master",
-		CLGrandine:   "develop",
-		ELNethermind: "master",
-		ELNimbusel:   "master",
-		ELBesu:       "main",
-		ELGeth:       "master",
-		ELReth:       "main",
-		ELErigon:     "main",
-		ELEthereumJS: "master",
 	}
 	// ClientsWithBuildArgs is a map of clients that support build arguments and their default values.
 	ClientsWithBuildArgs = map[string]struct {
 		BuildArgs    string
 		HasBuildArgs bool
 	}{
-		CLLighthouse: {
+		"lighthouse": {
 			HasBuildArgs: true,
 		},
 	}
 )
-
-// IsCLClient returns true if the client is a consensus client.
-func IsCLClient(client string) bool {
-	for _, c := range CLClients {
-		if c == client {
-			return true
-		}
-	}
-
-	return false
-}
-
-// IsELClient returns true if the client is an execution client.
-func IsELClient(client string) bool {
-	for _, c := range ELClients {
-		if c == client {
-			return true
-		}
-	}
-
-	return false
-}
-
-// GetClientLogo returns the Twitter profile image URL for a given client.
-func GetClientLogo(client string) string {
-	switch strings.ToLower(client) {
-	// Consensus Layer Clients
-	case CLLighthouse:
-		return "https://pbs.twimg.com/profile_images/1106229297151303681/EuqfU4v4_400x400.png"
-	case CLPrysm:
-		return "https://pbs.twimg.com/profile_images/1805984255861755905/PaPSwIzL_400x400.jpg"
-	case CLLodestar:
-		return "https://pbs.twimg.com/profile_images/1533709115712753665/O5PDykiV_400x400.jpg"
-	case CLNimbus:
-		return "https://pbs.twimg.com/profile_images/1721659785739960320/3XPpm8Or_400x400.jpg"
-	case CLTeku:
-		return "https://pbs.twimg.com/profile_images/1673661934036500480/Ee6NYB_K_400x400.jpg"
-	case CLGrandine:
-		return "https://pbs.twimg.com/profile_images/1409832041739345923/-ldZic7y_400x400.jpg"
-	// Execution Layer Clients
-	case ELNethermind:
-		return "https://pbs.twimg.com/profile_images/1806762018747072512/8XWySkUI_400x400.png"
-	case ELNimbusel:
-		return "https://pbs.twimg.com/profile_images/1721659785739960320/3XPpm8Or_400x400.jpg"
-	case ELBesu:
-		return "https://pbs.twimg.com/profile_images/1418537229123735552/XoFWio0T_400x400.jpg"
-	case ELGeth:
-		return "https://pbs.twimg.com/profile_images/1605238709451898881/Kl-bliNn_400x400.jpg"
-	case ELReth:
-		return "https://raw.githubusercontent.com/paradigmxyz/reth/refs/heads/main/assets/reth-docs.png"
-	case ELErigon:
-		return "https://pbs.twimg.com/profile_images/1420080204148576274/-4OFIs2x_400x400.jpg"
-	case ELEthereumJS:
-		return "https://pbs.twimg.com/profile_images/1330796558330322946/Y2YReI9m_400x400.png"
-	default:
-		return ""
-	}
-}
-
-// IsPreProductionClient returns true if the client is considered pre-production.
-func IsPreProductionClient(client string) bool {
-	return PreProductionClients[client]
-}
-
-// ClientSupportsBuildArgs returns whether the given client supports build arguments.
-func ClientSupportsBuildArgs(client string) bool {
-	if clientInfo, exists := ClientsWithBuildArgs[client]; exists {
-		return clientInfo.HasBuildArgs
-	}
-
-	return false
-}
-
-// GetClientDefaultBuildArgs returns the default build arguments for a client, if any.
-func GetClientDefaultBuildArgs(client string) string {
-	if clientInfo, exists := ClientsWithBuildArgs[client]; exists && clientInfo.BuildArgs != "" {
-		return clientInfo.BuildArgs
-	}
-
-	return ""
-}

--- a/pkg/clients/service.go
+++ b/pkg/clients/service.go
@@ -29,8 +29,7 @@ type Service struct {
 
 // NetworksData represents the structure of the networks.json file.
 type NetworksData struct {
-	Clients  map[string]ClientData `json:"clients"`
-	Networks map[string]Network    `json:"networks"`
+	Clients map[string]ClientData `json:"clients"`
 }
 
 // ClientData represents the structure of a client in the networks.json file.
@@ -44,25 +43,6 @@ type ClientData struct {
 	LatestVersion string `json:"latestVersion"`
 	WebsiteURL    string `json:"websiteUrl"`
 	DocsURL       string `json:"docsUrl"`
-}
-
-// Network represents a network in the networks.json file.
-type Network struct {
-	Name   string        `json:"name"`
-	Status string        `json:"status"`
-	Images *NetworkImage `json:"images,omitempty"`
-}
-
-// NetworkImage contains image information for a network.
-type NetworkImage struct {
-	URL     string          `json:"url"`
-	Clients []NetworkClient `json:"clients"`
-}
-
-// NetworkClient represents a client in a network.
-type NetworkClient struct {
-	Name    string `json:"name"`
-	Version string `json:"version"`
 }
 
 // ServiceConfig contains the configuration for the clients service.
@@ -456,19 +436,4 @@ func (s *Service) GetELClients() []string {
 // GetAdminRoles returns all admin roles.
 func (s *Service) GetAdminRoles() map[string]string {
 	return AdminRoles
-}
-
-// GetNetworksData returns a copy of the current networks data.
-func (s *Service) GetNetworksData() *NetworksData {
-	s.clientsMu.RLock()
-	defer s.clientsMu.RUnlock()
-
-	if s.remoteData == nil {
-		return nil
-	}
-
-	// Return a copy to prevent concurrent access issues
-	dataCopy := *s.remoteData
-
-	return &dataCopy
 }

--- a/pkg/clients/service.go
+++ b/pkg/clients/service.go
@@ -1,0 +1,474 @@
+package clients
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	defaultRefreshInterval = 1 * time.Hour
+	defaultRequestTimeout  = 30 * time.Second
+)
+
+// Service provides access to client data with automatic updates from a remote source.
+type Service struct {
+	log           *logrus.Logger
+	sourceURL     string
+	refreshTicker *time.Ticker
+	httpClient    *http.Client
+	stopChan      chan struct{}
+	clientsMu     sync.RWMutex
+	remoteData    *NetworksData
+}
+
+// NetworksData represents the structure of the networks.json file.
+type NetworksData struct {
+	Clients  map[string]ClientData `json:"clients"`
+	Networks map[string]Network    `json:"networks"`
+}
+
+// ClientData represents the structure of a client in the networks.json file.
+type ClientData struct {
+	Name          string `json:"name"`
+	DisplayName   string `json:"displayName"`
+	Repository    string `json:"repository"`
+	Type          string `json:"type"`
+	Branch        string `json:"branch"`
+	Logo          string `json:"logo"`
+	LatestVersion string `json:"latestVersion"`
+	WebsiteURL    string `json:"websiteUrl"`
+	DocsURL       string `json:"docsUrl"`
+}
+
+// Network represents a network in the networks.json file.
+type Network struct {
+	Name   string        `json:"name"`
+	Status string        `json:"status"`
+	Images *NetworkImage `json:"images,omitempty"`
+}
+
+// NetworkImage contains image information for a network.
+type NetworkImage struct {
+	URL     string          `json:"url"`
+	Clients []NetworkClient `json:"clients"`
+}
+
+// NetworkClient represents a client in a network.
+type NetworkClient struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+// ServiceConfig contains the configuration for the clients service.
+type ServiceConfig struct {
+	SourceURL       string
+	RefreshInterval time.Duration
+	Logger          *logrus.Logger
+	HTTPClient      *http.Client
+}
+
+// NewService creates a new clients service.
+func NewService(ctx context.Context, config ServiceConfig) (*Service, error) {
+	if config.SourceURL == "" {
+		config.SourceURL = "https://ethpandaops-platform-production-cartographoor.ams3.cdn.digitaloceanspaces.com/networks.json"
+	}
+
+	if config.RefreshInterval == 0 {
+		config.RefreshInterval = defaultRefreshInterval
+	}
+
+	if config.Logger == nil {
+		config.Logger = logrus.New()
+	}
+
+	httpClient := config.HTTPClient
+	if httpClient == nil {
+		httpClient = &http.Client{
+			Timeout: defaultRequestTimeout,
+		}
+	}
+
+	service := &Service{
+		log:           config.Logger,
+		sourceURL:     config.SourceURL,
+		refreshTicker: time.NewTicker(config.RefreshInterval),
+		httpClient:    httpClient,
+		stopChan:      make(chan struct{}),
+	}
+
+	// Perform initial fetch
+	if err := service.fetchAndUpdateData(ctx); err != nil {
+		return nil, fmt.Errorf("initial data fetch failed: %w", err)
+	}
+
+	return service, nil
+}
+
+// Start begins the periodic refresh of client data.
+func (s *Service) Start(ctx context.Context) {
+	go func() {
+		for {
+			select {
+			case <-s.refreshTicker.C:
+				if err := s.fetchAndUpdateData(ctx); err != nil {
+					s.log.WithError(err).Error("Failed to refresh client data")
+				}
+			case <-s.stopChan:
+				s.log.Info("Client service stopped")
+
+				return
+			case <-ctx.Done():
+				s.log.Info("Client service context done")
+
+				return
+			}
+		}
+	}()
+
+	s.log.Info("Client service started")
+}
+
+// Stop halts the periodic refresh of client data.
+func (s *Service) Stop() {
+	s.refreshTicker.Stop()
+
+	close(s.stopChan)
+}
+
+// fetchAndUpdateData retrieves the latest data from the remote source.
+func (s *Service) fetchAndUpdateData(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, defaultRequestTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.sourceURL, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to fetch data: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	var data NetworksData
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return fmt.Errorf("failed to decode data: %w", err)
+	}
+
+	s.clientsMu.Lock()
+	s.remoteData = &data
+	s.clientsMu.Unlock()
+
+	// Count client types for logging
+	var (
+		consensusCount = 0
+		executionCount = 0
+		unknownCount   = 0
+	)
+
+	for _, client := range data.Clients {
+		switch client.Type {
+		case string(ClientTypeCL):
+			consensusCount++
+		case string(ClientTypeEL):
+			executionCount++
+		default:
+			unknownCount++
+		}
+	}
+
+	s.log.WithFields(logrus.Fields{
+		"clients_count":     len(data.Clients),
+		"consensus_clients": consensusCount,
+		"execution_clients": executionCount,
+		"unknown_type":      unknownCount,
+	}).Info("Client data updated successfully")
+
+	return nil
+}
+
+// GetClientRepository returns the repository for a client.
+func (s *Service) GetClientRepository(clientName string) string {
+	s.clientsMu.RLock()
+	defer s.clientsMu.RUnlock()
+
+	if s.remoteData == nil {
+		return ""
+	}
+
+	if client, ok := s.remoteData.Clients[clientName]; ok {
+		return client.Repository
+	}
+
+	return ""
+}
+
+// GetClientBranch returns the default branch for a client.
+func (s *Service) GetClientBranch(clientName string) string {
+	s.clientsMu.RLock()
+	defer s.clientsMu.RUnlock()
+
+	if s.remoteData == nil {
+		return ""
+	}
+
+	if client, ok := s.remoteData.Clients[clientName]; ok {
+		return client.Branch
+	}
+
+	return ""
+}
+
+// GetClientLogo returns the logo URL for a client.
+func (s *Service) GetClientLogo(clientName string) string {
+	s.clientsMu.RLock()
+	defer s.clientsMu.RUnlock()
+
+	if s.remoteData == nil {
+		return ""
+	}
+
+	if client, ok := s.remoteData.Clients[clientName]; ok && client.Logo != "" {
+		return client.Logo
+	}
+
+	return ""
+}
+
+// GetClientLatestVersion returns the latest version for a client.
+func (s *Service) GetClientLatestVersion(clientName string) string {
+	s.clientsMu.RLock()
+	defer s.clientsMu.RUnlock()
+
+	if s.remoteData == nil {
+		return ""
+	}
+
+	if client, ok := s.remoteData.Clients[clientName]; ok {
+		return client.LatestVersion
+	}
+
+	return ""
+}
+
+// GetClientWebsiteURL returns the website URL for a client.
+func (s *Service) GetClientWebsiteURL(clientName string) string {
+	s.clientsMu.RLock()
+	defer s.clientsMu.RUnlock()
+
+	if s.remoteData == nil {
+		return ""
+	}
+
+	if client, ok := s.remoteData.Clients[clientName]; ok {
+		return client.WebsiteURL
+	}
+
+	return ""
+}
+
+// GetClientDocsURL returns the documentation URL for a client.
+func (s *Service) GetClientDocsURL(clientName string) string {
+	s.clientsMu.RLock()
+	defer s.clientsMu.RUnlock()
+
+	if s.remoteData == nil {
+		return ""
+	}
+
+	if client, ok := s.remoteData.Clients[clientName]; ok {
+		return client.DocsURL
+	}
+
+	return ""
+}
+
+// IsCLClient checks if a client is a consensus layer client.
+func (s *Service) IsCLClient(clientName string) bool {
+	s.clientsMu.RLock()
+	defer s.clientsMu.RUnlock()
+
+	if s.remoteData == nil {
+		return false
+	}
+
+	if client, ok := s.remoteData.Clients[clientName]; ok {
+		return client.Type == string(ClientTypeCL)
+	}
+
+	return false
+}
+
+// IsELClient checks if a client is an execution layer client.
+func (s *Service) IsELClient(clientName string) bool {
+	s.clientsMu.RLock()
+	defer s.clientsMu.RUnlock()
+
+	if s.remoteData == nil {
+		return false
+	}
+
+	if client, ok := s.remoteData.Clients[clientName]; ok {
+		return client.Type == string(ClientTypeEL)
+	}
+
+	return false
+}
+
+// GetClientDisplayName returns the display name for a client.
+func (s *Service) GetClientDisplayName(clientName string) string {
+	s.clientsMu.RLock()
+	defer s.clientsMu.RUnlock()
+
+	if s.remoteData == nil {
+		return clientName
+	}
+
+	if client, ok := s.remoteData.Clients[clientName]; ok && client.DisplayName != "" {
+		return client.DisplayName
+	}
+
+	return clientName
+}
+
+// GetClientType returns the type for a client (consensus or execution).
+func (s *Service) GetClientType(clientName string) string {
+	s.clientsMu.RLock()
+	defer s.clientsMu.RUnlock()
+
+	if s.remoteData == nil {
+		return ""
+	}
+
+	if client, ok := s.remoteData.Clients[clientName]; ok {
+		return client.Type
+	}
+
+	return ""
+}
+
+// GetConsensusClients returns all consensus clients from the remote data.
+func (s *Service) GetConsensusClients() []string {
+	s.clientsMu.RLock()
+	defer s.clientsMu.RUnlock()
+
+	if s.remoteData == nil {
+		return []string{}
+	}
+
+	clients := make([]string, 0)
+
+	for name, client := range s.remoteData.Clients {
+		if client.Type == string(ClientTypeCL) {
+			clients = append(clients, name)
+		}
+	}
+
+	return clients
+}
+
+// GetExecutionClients returns all execution clients from the remote data.
+func (s *Service) GetExecutionClients() []string {
+	s.clientsMu.RLock()
+	defer s.clientsMu.RUnlock()
+
+	if s.remoteData == nil {
+		return []string{}
+	}
+
+	clients := make([]string, 0)
+
+	for name, client := range s.remoteData.Clients {
+		if client.Type == string(ClientTypeEL) {
+			clients = append(clients, name)
+		}
+	}
+
+	return clients
+}
+
+// GetTeamRole returns the team role for a client.
+func (s *Service) GetTeamRole(clientName string) string {
+	return TeamRoles[clientName]
+}
+
+// IsPreProductionClient checks if a client is a pre-production client.
+func (s *Service) IsPreProductionClient(clientName string) bool {
+	return PreProductionClients[clientName]
+}
+
+// ClientSupportsBuildArgs checks if a client supports build arguments.
+func (s *Service) ClientSupportsBuildArgs(clientName string) bool {
+	if clientInfo, exists := ClientsWithBuildArgs[clientName]; exists {
+		return clientInfo.HasBuildArgs
+	}
+
+	return false
+}
+
+// GetClientDefaultBuildArgs returns the default build arguments for a client.
+func (s *Service) GetClientDefaultBuildArgs(clientName string) string {
+	if clientInfo, exists := ClientsWithBuildArgs[clientName]; exists && clientInfo.BuildArgs != "" {
+		return clientInfo.BuildArgs
+	}
+
+	return ""
+}
+
+// GetAllClients returns all known client names.
+func (s *Service) GetAllClients() []string {
+	s.clientsMu.RLock()
+	defer s.clientsMu.RUnlock()
+
+	if s.remoteData == nil {
+		return []string{}
+	}
+
+	clients := make([]string, 0, len(s.remoteData.Clients))
+	for name := range s.remoteData.Clients {
+		clients = append(clients, name)
+	}
+
+	return clients
+}
+
+// GetCLClients returns all consensus layer client names.
+func (s *Service) GetCLClients() []string {
+	return s.GetConsensusClients()
+}
+
+// GetELClients returns all execution layer client names.
+func (s *Service) GetELClients() []string {
+	return s.GetExecutionClients()
+}
+
+// GetAdminRoles returns all admin roles.
+func (s *Service) GetAdminRoles() map[string]string {
+	return AdminRoles
+}
+
+// GetNetworksData returns a copy of the current networks data.
+func (s *Service) GetNetworksData() *NetworksData {
+	s.clientsMu.RLock()
+	defer s.clientsMu.RUnlock()
+
+	if s.remoteData == nil {
+		return nil
+	}
+
+	// Return a copy to prevent concurrent access issues
+	dataCopy := *s.remoteData
+
+	return &dataCopy
+}

--- a/pkg/discord/bot.go
+++ b/pkg/discord/bot.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/bwmarrin/discordgo"
+	"github.com/ethpandaops/panda-pulse/pkg/clients"
 	cmdchecks "github.com/ethpandaops/panda-pulse/pkg/discord/cmd/checks"
 	"github.com/ethpandaops/panda-pulse/pkg/discord/cmd/common"
 	cmdhive "github.com/ethpandaops/panda-pulse/pkg/discord/cmd/hive"
@@ -35,6 +36,7 @@ type BotServices interface {
 	GetHiveSummaryRepo() *store.HiveSummaryRepo
 	GetGrafana() grafana.Client
 	GetHive() hive.Hive
+	GetClientsService() *clients.Service
 }
 
 // Bot is the interface for the Discord bot.
@@ -58,6 +60,7 @@ type DiscordBot struct {
 	hiveSummaryRepo *store.HiveSummaryRepo
 	grafana         grafana.Client
 	hive            hive.Hive
+	clientsService  *clients.Service
 	commands        []common.Command
 	metrics         *Metrics
 }
@@ -74,6 +77,7 @@ func NewBot(
 	grafana grafana.Client,
 	hive hive.Hive,
 	metrics *Metrics,
+	clientsService *clients.Service,
 ) (Bot, error) {
 	// Create a new Discord session.
 	session, err := discordgo.New("Bot " + cfg.DiscordToken)
@@ -92,6 +96,7 @@ func NewBot(
 		hiveSummaryRepo: hiveSummaryRepo,
 		grafana:         grafana,
 		hive:            hive,
+		clientsService:  clientsService,
 		commands:        make([]common.Command, 0),
 		metrics:         metrics,
 	}
@@ -181,6 +186,11 @@ func (b *DiscordBot) GetGrafana() grafana.Client {
 // GetHive returns the Hive client.
 func (b *DiscordBot) GetHive() hive.Hive {
 	return b.hive
+}
+
+// GetClientsService returns the clients service.
+func (b *DiscordBot) GetClientsService() *clients.Service {
+	return b.clientsService
 }
 
 // handleInteraction handles Discord command interactions.

--- a/pkg/discord/cmd/build/utils.go
+++ b/pkg/discord/cmd/build/utils.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 
 	"github.com/bwmarrin/discordgo"
-	"github.com/ethpandaops/panda-pulse/pkg/clients"
 	"github.com/ethpandaops/panda-pulse/pkg/discord/cmd/common"
 )
 
@@ -97,9 +96,9 @@ var AdditionalWorkflows = map[string]struct {
 }
 
 // HasBuildArgs returns whether the given workflow or client supports build arguments.
-func HasBuildArgs(target string) bool {
+func (c *BuildCommand) HasBuildArgs(target string) bool {
 	// Check client workflows first
-	if clients.ClientSupportsBuildArgs(target) {
+	if c.bot.GetClientsService().ClientSupportsBuildArgs(target) {
 		return true
 	}
 
@@ -112,9 +111,9 @@ func HasBuildArgs(target string) bool {
 }
 
 // GetDefaultBuildArgs returns the default build arguments for a workflow or client, if any.
-func GetDefaultBuildArgs(target string) string {
+func (c *BuildCommand) GetDefaultBuildArgs(target string) string {
 	// Check client workflows first.
-	clientBuildArgs := clients.GetClientDefaultBuildArgs(target)
+	clientBuildArgs := c.bot.GetClientsService().GetClientDefaultBuildArgs(target)
 	if clientBuildArgs != "" {
 		return clientBuildArgs
 	}
@@ -130,11 +129,12 @@ func GetDefaultBuildArgs(target string) string {
 // getCLClientChoices returns the choices for consensus layer client selection.
 func (c *BuildCommand) getCLClientChoices() []*discordgo.ApplicationCommandOptionChoice {
 	choices := make([]*discordgo.ApplicationCommandOptionChoice, 0)
+	clientsService := c.bot.GetClientsService()
 
 	// Add consensus clients
-	for _, client := range clients.CLClients {
+	for _, client := range clientsService.GetCLClients() {
 		choices = append(choices, &discordgo.ApplicationCommandOptionChoice{
-			Name:  client,
+			Name:  clientsService.GetClientDisplayName(client),
 			Value: client,
 		})
 	}
@@ -145,11 +145,12 @@ func (c *BuildCommand) getCLClientChoices() []*discordgo.ApplicationCommandOptio
 // getELClientChoices returns the choices for execution layer client selection.
 func (c *BuildCommand) getELClientChoices() []*discordgo.ApplicationCommandOptionChoice {
 	choices := make([]*discordgo.ApplicationCommandOptionChoice, 0)
+	clientsService := c.bot.GetClientsService()
 
 	// Add execution clients
-	for _, client := range clients.ELClients {
+	for _, client := range clientsService.GetELClients() {
 		choices = append(choices, &discordgo.ApplicationCommandOptionChoice{
-			Name:  client,
+			Name:  clientsService.GetClientDisplayName(client),
 			Value: client,
 		})
 	}

--- a/pkg/discord/cmd/checks/command.go
+++ b/pkg/discord/cmd/checks/command.go
@@ -250,7 +250,7 @@ func (c *ChecksCommand) RunChecks(ctx context.Context, alert *store.MonitorAlert
 func (c *ChecksCommand) setupRunner(alert *store.MonitorAlert) (checks.Runner, error) {
 	var consensusNode, executionNode string
 
-	if clients.IsELClient(alert.Client) {
+	if c.bot.GetClientsService().IsELClient(alert.Client) {
 		executionNode = alert.Client
 	} else {
 		consensusNode = alert.Client
@@ -260,7 +260,7 @@ func (c *ChecksCommand) setupRunner(alert *store.MonitorAlert) (checks.Runner, e
 		Network:       alert.Network,
 		ConsensusNode: consensusNode,
 		ExecutionNode: executionNode,
-	})
+	}, c.bot.GetClientsService())
 
 	runner.RegisterCheck(checks.NewCLSyncCheck(c.bot.GetGrafana()))
 	runner.RegisterCheck(checks.NewHeadSlotCheck(c.bot.GetGrafana()))
@@ -361,6 +361,7 @@ func (c *ChecksCommand) sendResults(ctx context.Context, alert *store.MonitorAle
 		GrafanaBaseURL: c.bot.GetGrafana().GetBaseURL(),
 		HiveBaseURL:    c.bot.GetHive().GetBaseURL(),
 		RootCauses:     analysis.RootCause,
+		ClientsService: c.bot.GetClientsService(),
 	})
 
 	// Process the data to detect infrastructure issues.
@@ -408,7 +409,7 @@ func (c *ChecksCommand) sendResults(ctx context.Context, alert *store.MonitorAle
 		// Get a screenshot of the test coverage.
 		var consensusNode, executionNode string
 
-		if clients.IsELClient(alert.Client) {
+		if c.bot.GetClientsService().IsELClient(alert.Client) {
 			executionNode = alert.Client
 		} else {
 			consensusNode = alert.Client

--- a/pkg/discord/cmd/checks/list.go
+++ b/pkg/discord/cmd/checks/list.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/bwmarrin/discordgo"
-	"github.com/ethpandaops/panda-pulse/pkg/clients"
 	"github.com/ethpandaops/panda-pulse/pkg/store"
 	"github.com/robfig/cron/v3"
 )
@@ -96,7 +95,7 @@ func (c *ChecksCommand) handleList(
 		// Create a map of registered clients for this network.
 		var (
 			registered = make(map[string]clientInfo)
-			allClients = append(clients.CLClients, clients.ELClients...)
+			allClients = c.bot.GetClientsService().GetAllClients()
 		)
 
 		// Initialize all clients as unregistered.

--- a/pkg/discord/cmd/checks/register.go
+++ b/pkg/discord/cmd/checks/register.go
@@ -140,12 +140,12 @@ func (c *ChecksCommand) registerAlert(ctx context.Context, network, channelID, g
 		}
 	}
 
-	clientType := getClientType(*specificClient)
-	if clientType == clients.ClientTypeAll {
+	clientType := c.bot.GetClientsService().GetClientType(*specificClient)
+	if clientType == string(clients.ClientTypeAll) {
 		return fmt.Errorf("unknown client: %s", *specificClient)
 	}
 
-	alert := newMonitorAlert(network, *specificClient, clientType, channelID, guildID)
+	alert := newMonitorAlert(network, *specificClient, clients.ClientType(clientType), channelID, guildID)
 	alert.Schedule = schedule
 
 	if err := c.scheduleAlert(ctx, alert); err != nil {
@@ -158,7 +158,7 @@ func (c *ChecksCommand) registerAlert(ctx context.Context, network, channelID, g
 // registerAllClients registers a monitor alert for all clients for a given network.
 func (c *ChecksCommand) registerAllClients(ctx context.Context, network, channelID, guildID string, schedule string) error {
 	// Register CL clients.
-	for _, client := range clients.CLClients {
+	for _, client := range c.bot.GetClientsService().GetCLClients() {
 		alert := newMonitorAlert(network, client, clients.ClientTypeCL, channelID, guildID)
 		alert.Schedule = schedule
 
@@ -168,7 +168,7 @@ func (c *ChecksCommand) registerAllClients(ctx context.Context, network, channel
 	}
 
 	// Register EL clients.
-	for _, client := range clients.ELClients {
+	for _, client := range c.bot.GetClientsService().GetELClients() {
 		alert := newMonitorAlert(network, client, clients.ClientTypeEL, channelID, guildID)
 		alert.Schedule = schedule
 
@@ -234,18 +234,18 @@ func newMonitorAlert(network, client string, clientType clients.ClientType, chan
 }
 
 // getClientType determines the client type from a client name.
-func getClientType(clientName string) clients.ClientType {
-	for _, c := range clients.CLClients {
-		if c == clientName {
-			return clients.ClientTypeCL
-		}
-	}
+// func getClientType(clientName string) clients.ClientType {
+// 	for _, c := range clients.CLClients {
+// 		if c == clientName {
+// 			return clients.ClientTypeCL
+// 		}
+// 	}
 
-	for _, c := range clients.ELClients {
-		if c == clientName {
-			return clients.ClientTypeEL
-		}
-	}
+// 	for _, c := range clients.ELClients {
+// 		if c == clientName {
+// 			return clients.ClientTypeEL
+// 		}
+// 	}
 
-	return clients.ClientTypeAll
-}
+// 	return clients.ClientTypeAll
+// }

--- a/pkg/discord/cmd/checks/register.go
+++ b/pkg/discord/cmd/checks/register.go
@@ -232,20 +232,3 @@ func newMonitorAlert(network, client string, clientType clients.ClientType, chan
 		Enabled:        true,
 	}
 }
-
-// getClientType determines the client type from a client name.
-// func getClientType(clientName string) clients.ClientType {
-// 	for _, c := range clients.CLClients {
-// 		if c == clientName {
-// 			return clients.ClientTypeCL
-// 		}
-// 	}
-
-// 	for _, c := range clients.ELClients {
-// 		if c == clientName {
-// 			return clients.ClientTypeEL
-// 		}
-// 	}
-
-// 	return clients.ClientTypeAll
-// }

--- a/pkg/discord/cmd/checks/utils.go
+++ b/pkg/discord/cmd/checks/utils.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/bwmarrin/discordgo"
 	"github.com/ethpandaops/panda-pulse/pkg/checks"
-	"github.com/ethpandaops/panda-pulse/pkg/clients"
 )
 
 // categoryResults is a struct that holds the results of a category.
@@ -23,15 +22,8 @@ var orderedCategories = []checks.Category{
 
 // getClientChoices returns the choices for the client dropdown.
 func (c *ChecksCommand) getClientChoices() []*discordgo.ApplicationCommandOptionChoice {
-	choices := make([]*discordgo.ApplicationCommandOptionChoice, 0, len(clients.CLClients)+len(clients.ELClients))
-	for _, client := range clients.CLClients {
-		choices = append(choices, &discordgo.ApplicationCommandOptionChoice{
-			Name:  client,
-			Value: client,
-		})
-	}
-
-	for _, client := range clients.ELClients {
+	choices := make([]*discordgo.ApplicationCommandOptionChoice, 0, len(c.bot.GetClientsService().GetAllClients()))
+	for _, client := range c.bot.GetClientsService().GetAllClients() {
 		choices = append(choices, &discordgo.ApplicationCommandOptionChoice{
 			Name:  client,
 			Value: client,

--- a/pkg/discord/cmd/common/types.go
+++ b/pkg/discord/cmd/common/types.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/bwmarrin/discordgo"
+	"github.com/ethpandaops/panda-pulse/pkg/clients"
 	"github.com/ethpandaops/panda-pulse/pkg/grafana"
 	"github.com/ethpandaops/panda-pulse/pkg/hive"
 	"github.com/ethpandaops/panda-pulse/pkg/scheduler"
@@ -45,6 +46,8 @@ type BotContext interface {
 	GetGrafana() grafana.Client
 	// GetHive returns the Hive client.
 	GetHive() hive.Hive
+	// GetClientsService returns the clients service.
+	GetClientsService() *clients.Service
 	// GetRoleConfig returns the role configuration.
 	GetRoleConfig() *RoleConfig
 }

--- a/pkg/discord/cmd/mentions/list.go
+++ b/pkg/discord/cmd/mentions/list.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/bwmarrin/discordgo"
-	"github.com/ethpandaops/panda-pulse/pkg/clients"
 	"github.com/ethpandaops/panda-pulse/pkg/store"
 )
 
@@ -79,7 +78,7 @@ func (c *MentionsCommand) handleList(
 			}
 		}
 
-		msg := fmt.Sprintf(msgNetworkMentions, networkName) + buildMentionsTable(clientMentions)
+		msg := fmt.Sprintf(msgNetworkMentions, networkName) + c.buildMentionsTable(clientMentions)
 
 		if respondErr := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 			Type: discordgo.InteractionResponseChannelMessageWithSource,
@@ -128,11 +127,11 @@ func (c *MentionsCommand) listMentions(ctx context.Context, guildID string, netw
 }
 
 // buildMentionsTable creates an ASCII table of client mentions.
-func buildMentionsTable(mentions map[string]*store.ClientMention) string {
+func (c *MentionsCommand) buildMentionsTable(mentions map[string]*store.ClientMention) string {
 	var msg strings.Builder
 
 	// Get all available clients.
-	allClients := append(clients.CLClients, clients.ELClients...)
+	allClients := c.bot.GetClientsService().GetAllClients()
 	sort.Strings(allClients)
 
 	msg.WriteString("```\n")

--- a/pkg/discord/cmd/mentions/utils.go
+++ b/pkg/discord/cmd/mentions/utils.go
@@ -5,20 +5,12 @@ import (
 	"log"
 
 	"github.com/bwmarrin/discordgo"
-	"github.com/ethpandaops/panda-pulse/pkg/clients"
 )
 
 // getClientChoices returns the choices for the client dropdown.
 func (c *MentionsCommand) getClientChoices() []*discordgo.ApplicationCommandOptionChoice {
-	choices := make([]*discordgo.ApplicationCommandOptionChoice, 0, len(clients.CLClients)+len(clients.ELClients))
-	for _, client := range clients.CLClients {
-		choices = append(choices, &discordgo.ApplicationCommandOptionChoice{
-			Name:  client,
-			Value: client,
-		})
-	}
-
-	for _, client := range clients.ELClients {
+	choices := make([]*discordgo.ApplicationCommandOptionChoice, 0, len(c.bot.GetClientsService().GetAllClients()))
+	for _, client := range c.bot.GetClientsService().GetAllClients() {
 		choices = append(choices, &discordgo.ApplicationCommandOptionChoice{
 			Name:  client,
 			Value: client,

--- a/pkg/discord/mock/bot.mock.go
+++ b/pkg/discord/mock/bot.mock.go
@@ -14,6 +14,7 @@ import (
 	reflect "reflect"
 
 	discordgo "github.com/bwmarrin/discordgo"
+	clients "github.com/ethpandaops/panda-pulse/pkg/clients"
 	common "github.com/ethpandaops/panda-pulse/pkg/discord/cmd/common"
 	grafana "github.com/ethpandaops/panda-pulse/pkg/grafana"
 	hive "github.com/ethpandaops/panda-pulse/pkg/hive"
@@ -59,6 +60,20 @@ func (m *MockBot) GetChecksRepo() *store.ChecksRepo {
 func (mr *MockBotMockRecorder) GetChecksRepo() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChecksRepo", reflect.TypeOf((*MockBot)(nil).GetChecksRepo))
+}
+
+// GetClientsService mocks base method.
+func (m *MockBot) GetClientsService() *clients.Service {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetClientsService")
+	ret0, _ := ret[0].(*clients.Service)
+	return ret0
+}
+
+// GetClientsService indicates an expected call of GetClientsService.
+func (mr *MockBotMockRecorder) GetClientsService() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClientsService", reflect.TypeOf((*MockBot)(nil).GetClientsService))
 }
 
 // GetGrafana mocks base method.

--- a/pkg/service/config.go
+++ b/pkg/service/config.go
@@ -3,6 +3,7 @@ package service
 import (
 	"fmt"
 
+	"github.com/ethpandaops/panda-pulse/pkg/clients"
 	"github.com/ethpandaops/panda-pulse/pkg/discord"
 	"github.com/ethpandaops/panda-pulse/pkg/grafana"
 	"github.com/ethpandaops/panda-pulse/pkg/hive"
@@ -22,6 +23,7 @@ type Config struct {
 	S3BucketPrefix     string
 	S3Region           string
 	S3EndpointURL      string
+	ClientsDataURL     string
 	MetricsAddress     string // Defaults to :9091
 	HealthCheckAddress string // Defaults to :9191
 }
@@ -59,6 +61,13 @@ func (c *Config) AsGrafanaConfig() *grafana.Config {
 func (c *Config) AsHiveConfig() *hive.Config {
 	return &hive.Config{
 		BaseURL: hive.BaseURL,
+	}
+}
+
+// AsClientsConfig converts the configuration to a ClientsConfig.
+func (c *Config) AsClientsConfig() clients.ServiceConfig {
+	return clients.ServiceConfig{
+		SourceURL: c.ClientsDataURL,
 	}
 }
 


### PR DESCRIPTION
Introduces the concept of a `ClientsService` which fetches its data from catographoor, replacing a lot of hardcoded client information and categorisation work. Client data is fetched (from catographoor) on boot, and refreshed every hour. 

```
refactor(checks): inject clients service into checks runner
feat(clients): add new clients service to fetch and manage client data
refactor(clients): remove static client data and functions
feat(clients): add new clients service to fetch and manage client data
refactor(discord): inject clients service into discord bot
refactor(discord): use clients service for client data in build command
refactor(discord): use clients service for client data in checks command
refactor(discord): use clients service for client data in mentions command
refactor(discord): use clients service for client data in alert message builder
refactor(service): initialize and start clients service
refactor(service): inject clients service into discord bot
```

Example:

```bash
INFO[2025-05-09T13:54:41+10:00] Starting service
INFO[2025-05-09T13:54:42+10:00] Client data updated successfully              clients_count=13 consensus_clients=6 execution_clients=7 unknown_type=0
INFO[2025-05-09T13:54:42+10:00] Client service started
INFO[2025-05-09T13:54:42+10:00] Verified S3 connection                        bucket=panda-pulse prefix=ethrand
INFO[2025-05-09T13:54:42+10:00] Starting health server                        address=":9191" endpoint=/healthz
INFO[2025-05-09T13:54:42+10:00] Starting metrics server                       address=":9091" endpoint=/metrics
INFO[2025-05-09T13:54:42+10:00] Starting scheduler
INFO[2025-05-09T13:54:42+10:00] Starting discord bot
```