### PR TITLE
feat(discord): add periodic refresh of discord command choices

### DIFF
--- a/pkg/discord/bot.go
+++ b/pkg/discord/bot.go
@@ -138,6 +138,11 @@ func (b *DiscordBot) Start(ctx context.Context) error {
 		return fmt.Errorf("failed to schedule existing alerts: %w", err)
 	}
 
+	// Schedule periodic refresh of discord command choices.
+	if err := b.scheduleDiscordChoiceRefresh(); err != nil {
+		return fmt.Errorf("failed to schedule choice refresh: %w", err)
+	}
+
 	return nil
 }
 
@@ -400,4 +405,42 @@ func (b *DiscordBot) GetQueues() []queue.Queuer {
 	}
 
 	return queues
+}
+
+// RefreshCommandChoices refreshes the choices for all commands that support it.
+func (b *DiscordBot) RefreshCommandChoices() error {
+	b.log.Info("Refreshing command choices")
+
+	for _, cmd := range b.commands {
+		// Check if command supports choice updates.
+		if updater, ok := cmd.(interface {
+			UpdateChoices(*discordgo.Session) error
+		}); ok {
+			if err := updater.UpdateChoices(b.session); err != nil {
+				return fmt.Errorf("failed to update choices for command %s: %w", cmd.Name(), err)
+			}
+
+			b.log.WithField("command", cmd.Name()).Info("Successfully updated command choices")
+		}
+	}
+
+	return nil
+}
+
+// scheduleDiscordChoiceRefresh schedules periodic refresh of command choices. Our cartographoor service
+// is updated every hour, so we need to refresh the command choices to reflect the latest data as once
+// a discord command is registered, we need to refresh the choices to reflect any changes.
+func (b *DiscordBot) scheduleDiscordChoiceRefresh() error {
+	// Refresh choices every hour.
+	if err := b.scheduler.AddJob("refresh-command-choices", "*/15 * * * *", func(ctx context.Context) error {
+		b.log.Info("Running scheduled command choices refresh")
+
+		return b.RefreshCommandChoices()
+	}); err != nil {
+		return fmt.Errorf("failed to schedule choice refresh: %w", err)
+	}
+
+	b.log.Info("Scheduled bot command refresh")
+
+	return nil
 }

--- a/pkg/discord/cmd/build/command.go
+++ b/pkg/discord/cmd/build/command.go
@@ -127,6 +127,11 @@ func (c *BuildCommand) Register(session *discordgo.Session) error {
 	return nil
 }
 
+// UpdateChoices updates the command choices by re-registering with fresh client and tool data.
+func (c *BuildCommand) UpdateChoices(session *discordgo.Session) error {
+	return c.Register(session)
+}
+
 // Handle handles the /build command.
 func (c *BuildCommand) Handle(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	if i.Type != discordgo.InteractionApplicationCommand {

--- a/pkg/discord/cmd/checks/command.go
+++ b/pkg/discord/cmd/checks/command.go
@@ -183,6 +183,11 @@ func (c *ChecksCommand) Register(session *discordgo.Session) error {
 	return nil
 }
 
+// UpdateChoices updates the command choices by re-registering with fresh network and client data.
+func (c *ChecksCommand) UpdateChoices(session *discordgo.Session) error {
+	return c.Register(session)
+}
+
 // Handle handles the /checks command.
 func (c *ChecksCommand) Handle(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	if i.Type != discordgo.InteractionApplicationCommand {

--- a/pkg/discord/cmd/hive/command.go
+++ b/pkg/discord/cmd/hive/command.go
@@ -133,6 +133,11 @@ func (c *HiveCommand) Register(session *discordgo.Session) error {
 	return err
 }
 
+// UpdateChoices updates the command choices by re-registering with fresh network data.
+func (c *HiveCommand) UpdateChoices(session *discordgo.Session) error {
+	return c.Register(session)
+}
+
 // Handle handles the command.
 func (c *HiveCommand) Handle(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	// Only respond to application commands

--- a/pkg/discord/cmd/mentions/command.go
+++ b/pkg/discord/cmd/mentions/command.go
@@ -156,6 +156,11 @@ func (c *MentionsCommand) Register(session *discordgo.Session) error {
 	return nil
 }
 
+// UpdateChoices updates the command choices by re-registering with fresh network and client data.
+func (c *MentionsCommand) UpdateChoices(session *discordgo.Session) error {
+	return c.Register(session)
+}
+
 // Handle handles the /mentions command.
 func (c *MentionsCommand) Handle(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	if i.Type != discordgo.InteractionApplicationCommand {


### PR DESCRIPTION
This change introduces a mechanism to periodically refresh the choices available for Discord commands. This is necessary because the data used to populate command choices (e.g., client names, networks) is updated externally by the cartographoor service. By refreshing the choices every 15 minutes, the bot ensures that the command options presented to users are up-to-date with the latest data.

The `DiscordBot` now includes a `RefreshCommandChoices` method that iterates through registered commands and calls an `UpdateChoices` method if the command implements the corresponding interface. A new `scheduleDiscordChoiceRefresh` method schedules this refresh to run periodically using the existing scheduler.

Commands that require choice updates (build, checks, hive, mentions) now implement the `UpdateChoices` interface by simply calling their `Register` method again, which fetches the latest data and updates the command choices.