### PR TITLE
feat(build): prepend organization to docker tag for forked repositories

### DIFF
--- a/pkg/discord/cmd/build/trigger.go
+++ b/pkg/discord/cmd/build/trigger.go
@@ -154,6 +154,32 @@ func (c *BuildCommand) handleBuild(s *discordgo.Session, i *discordgo.Interactio
 		}
 	}
 
+	// Check if we need to prepend organization to docker tag
+	if dockerTag == "" && repository != "" {
+		// Get the official repository for comparison
+		officialRepo := ""
+		allWorkflows, err := c.workflowFetcher.GetAllWorkflows()
+
+		if err == nil {
+			workflowName := getClientToWorkflowName(targetName)
+			if workflow, exists := allWorkflows[workflowName]; exists {
+				officialRepo = workflow.Repository
+			}
+		}
+
+		// If building from a fork, prepend the organization name
+		if shouldPrependOrganization(repository, officialRepo, dockerTag) {
+			if org := extractOrganization(repository); org != "" {
+				dockerTag = fmt.Sprintf("%s-%s", org, ref)
+				c.log.WithFields(logrus.Fields{
+					"repository": repository,
+					"official":   officialRepo,
+					"docker_tag": dockerTag,
+				}).Debug("Auto-generated docker tag for forked repository")
+			}
+		}
+	}
+
 	// Use default build args if provided and user didn't specify any.
 	if buildArgs == "" && c.HasBuildArgs(targetName) {
 		buildArgs = c.GetDefaultBuildArgs(targetName)

--- a/pkg/discord/cmd/build/utils.go
+++ b/pkg/discord/cmd/build/utils.go
@@ -186,3 +186,44 @@ func getClientToWorkflowName(clientName string) string {
 func stringPtr(s string) *string {
 	return &s
 }
+
+// isOfficialRepository compares two repository paths to determine if they are the same.
+// Examples:
+//
+//	isOfficialRepository("ethereum/go-ethereum", "ethereum/go-ethereum") → true
+//	isOfficialRepository("mattevans/go-ethereum", "ethereum/go-ethereum") → false
+func isOfficialRepository(providedRepo, officialRepo string) bool {
+	return strings.EqualFold(providedRepo, officialRepo)
+}
+
+// extractOrganization extracts the organization/username from a repository path.
+// Examples:
+//
+//	extractOrganization("ethereum/go-ethereum") → "ethereum"
+//	extractOrganization("mattevans/prysm") → "mattevans"
+//	extractOrganization("go-ethereum") → ""
+func extractOrganization(repository string) string {
+	parts := strings.Split(repository, "/")
+	if len(parts) >= 2 {
+		return parts[0]
+	}
+
+	return ""
+}
+
+// shouldPrependOrganization determines if organization should be prepended to docker tag.
+// Returns true only if:
+// 1. dockerTag is empty (not provided by user).
+// 2. providedRepo is different from officialRepo.
+// 3. providedRepo has a valid organization prefix.
+func shouldPrependOrganization(providedRepo, officialRepo, dockerTag string) bool {
+	if dockerTag != "" {
+		return false
+	}
+
+	if isOfficialRepository(providedRepo, officialRepo) {
+		return false
+	}
+
+	return extractOrganization(providedRepo) != ""
+}


### PR DESCRIPTION
When building from a forked repository via the Discord bot's /build command, automatically prepend the fork's organization name to the Docker tag.

Example:

```
/build client-cl client:prysm repository:mattevans/prysm
```

Previously: 
- Docker tag would be `master`
- Now: Docker tag will be `mattevans-master`

![Screenshot 2025-07-03 at 09 44 28](https://github.com/user-attachments/assets/4f71490c-2f0a-46fc-afa9-37a4bfb7815d)
