### PR TITLE
chore: upgrade golangci-lint to 2.4.0 and migrate wsl to wsl_v5

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -60,11 +60,10 @@ linters:
     nolintlint:
       require-explanation: true
       require-specific: true
-    settings:
-      wsl_v5:
-        allow-first-in-block: true
-        allow-whole-block: false
-        branch-max-lines: 2
+    wsl_v5:
+      allow-first-in-block: true
+      allow-whole-block: false
+      branch-max-lines: 2
   exclusions:
     generated: lax
     presets:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,7 +40,7 @@ linters:
     - unconvert
     - unused
     - whitespace
-    - wsl
+    - wsl_v5
   settings:
     errcheck:
       check-type-assertions: true
@@ -60,6 +60,11 @@ linters:
     nolintlint:
       require-explanation: true
       require-specific: true
+    settings:
+      wsl_v5:
+        allow-first-in-block: true
+        allow-whole-block: false
+        branch-max-lines: 2
   exclusions:
     generated: lax
     presets:
@@ -71,7 +76,7 @@ linters:
       - linters:
           - gocritic
           - gosec
-          - wsl
+          - wsl_v5
         path: _test\.go
     paths:
       - third_party$

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golangci-lint 2.0.1
+golangci-lint 2.4.0

--- a/pkg/discord/cmd/build/workflow_fetcher.go
+++ b/pkg/discord/cmd/build/workflow_fetcher.go
@@ -104,6 +104,7 @@ func (wf *WorkflowFetcher) RefreshCache() error {
 // GetAllWorkflows returns all workflows from the GitHub repository.
 func (wf *WorkflowFetcher) GetAllWorkflows() (map[string]WorkflowInfo, error) {
 	wf.cacheMutex.RLock()
+
 	if time.Since(wf.lastUpdated) < wf.cacheExpiration && len(wf.cache) > 0 {
 		// Return cached data
 		result := make(map[string]WorkflowInfo)
@@ -116,6 +117,7 @@ func (wf *WorkflowFetcher) GetAllWorkflows() (map[string]WorkflowInfo, error) {
 
 		return result, nil
 	}
+
 	wf.cacheMutex.RUnlock()
 
 	// Need to fetch fresh data
@@ -123,6 +125,7 @@ func (wf *WorkflowFetcher) GetAllWorkflows() (map[string]WorkflowInfo, error) {
 	if err != nil {
 		// If we have stale cache data, use it rather than failing completely
 		wf.cacheMutex.RLock()
+
 		if len(wf.cache) > 0 {
 			wf.log.WithError(err).Warn("Failed to fetch fresh workflows, using stale cache")
 

--- a/pkg/discord/cmd/checks/list.go
+++ b/pkg/discord/cmd/checks/list.go
@@ -153,7 +153,6 @@ func (c *ChecksCommand) handleList(
 			_, err = s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
 				Content: pointer(msg.String()),
 			})
-
 			if err != nil {
 				c.log.WithError(err).WithField("network", networkName).Error("Failed to edit response for first network")
 			}
@@ -165,7 +164,6 @@ func (c *ChecksCommand) handleList(
 				Content: msg.String(),
 				Flags:   discordgo.MessageFlagsEphemeral,
 			})
-
 			if err != nil {
 				c.log.WithError(err).WithField("network", networkName).Error("Failed to send follow-up for network")
 			}

--- a/pkg/discord/cmd/hive/list.go
+++ b/pkg/discord/cmd/hive/list.go
@@ -120,7 +120,6 @@ func (c *HiveCommand) handleList(
 			_, err = s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
 				Content: pointer(msg.String()),
 			})
-
 			if err != nil {
 				c.log.WithError(err).WithField("network", networkName).Error("Failed to edit response for first network")
 			}
@@ -132,7 +131,6 @@ func (c *HiveCommand) handleList(
 				Content: msg.String(),
 				Flags:   discordgo.MessageFlagsEphemeral,
 			})
-
 			if err != nil {
 				c.log.WithError(err).WithField("network", networkName).Error("Failed to send follow-up for network")
 			}

--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -74,6 +74,7 @@ func (q *Queue[T]) Enqueue(item T) {
 
 	q.metrics.queuedTotal.WithLabelValues(q.getItemNetwork(item), q.getItemClient(item)).Inc()
 	q.metrics.queueLength.Inc()
+
 	q.queue <- item
 }
 

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -56,7 +56,6 @@ func (s *Scheduler) AddJob(name, schedule string, run func(context.Context) erro
 
 		s.metrics.executionTime.WithLabelValues(name).Observe(time.Since(start).Seconds())
 	})
-
 	if err != nil {
 		return fmt.Errorf("failed to add job %s: %w", name, err)
 	}


### PR DESCRIPTION
chore(.golangci.yml): replace deprecated wsl linter with wsl_v5
chore(.golangci.yml): configure wsl_v5 settings for stricter formatting
style: add blank lines after mutex unlocks to satisfy wsl_v5 rules
style: remove extra blank lines after error checks