### PR TITLE
refactor(hive): update hive

### DIFF
--- a/pkg/discord/cmd/hive/summary.go
+++ b/pkg/discord/cmd/hive/summary.go
@@ -35,7 +35,7 @@ func (c *HiveCommand) sendHiveSummary(
 	if networkName != "" {
 		// Use the mapped network name for the Hive URL
 		hiveNetworkName := c.bot.GetHive().MapNetworkName(networkName)
-		hiveURL := fmt.Sprintf("https://hive.ethpandaops.io/%s/index.html", hiveNetworkName)
+		hiveURL := fmt.Sprintf("https://hive.ethpandaops.io/#/group/%s", hiveNetworkName)
 
 		messageSend.Components = []discordgo.MessageComponent{
 			discordgo.ActionsRow{

--- a/pkg/hive/config.go
+++ b/pkg/hive/config.go
@@ -9,6 +9,13 @@ type Config struct {
 	BaseURL string
 }
 
+// DiscoveryEntry represents an entry in the Hive discovery.json response.
+type DiscoveryEntry struct {
+	Name            string   `json:"name"`
+	Address         string   `json:"address"`
+	GithubWorkflows []string `json:"github_workflows"` //nolint:tagliatelle // API uses snake_case
+}
+
 // SnapshotConfig contains configuration for taking a screenshot of the test coverage.
 type SnapshotConfig struct {
 	Network       string


### PR DESCRIPTION
- Remove shared AutocompleteHandler dependency to simplify code
- Inline network autocomplete directly into HiveCommand
- Fetch live networks from Hive discovery.json instead of hard-coded list
- Update Hive availability check to use discovery.json endpoint
- Change Hive URL format to new group-based structure