### PR TITLE
fix(hive): exclude consume-sync tests from individual client stats

### DIFF
--- a/pkg/discord/cmd/hive/summary.go
+++ b/pkg/discord/cmd/hive/summary.go
@@ -389,6 +389,11 @@ func buildTestSuiteLinks(clientName string, results []hive.TestResult, network s
 			continue
 		}
 
+		// Skip consume-sync tests as they are suite-level tests
+		if result.Name == "eest/consume-sync" {
+			continue
+		}
+
 		// Check if we already have a timestamp for this test type.
 		currentTimestamp, exists := latestTimestamps[result.Name]
 		if !exists || result.Timestamp.After(currentTimestamp) {


### PR DESCRIPTION
`consume-sync` tests are suite-level tests that should not be attributed to any single client. They are now processed separately and only contribute to the overall summary totals, preventing misleading pass/fail rates for individual clients.