### PR TITLE
feat: add optional test-suite filter to all /hive commands

### DIFF
--- a/pkg/discord/cmd/hive/list.go
+++ b/pkg/discord/cmd/hive/list.go
@@ -176,10 +176,28 @@ func (c *HiveCommand) listAlerts(ctx context.Context, guildID string, network *s
 func buildSummaryTable(alerts []*hive.HiveSummaryAlert, networkName string) string {
 	var msg strings.Builder
 
+	// Check if any alerts have suite specified
+	hasSuite := false
+
+	for _, alert := range alerts {
+		if alert.Network == networkName && alert.Suite != "" {
+			hasSuite = true
+
+			break
+		}
+	}
+
 	msg.WriteString("```\n")
-	msg.WriteString("┌──────────────────┬────────┬────────────────────┐\n")
-	msg.WriteString("│ Network          │ Status │ Next Run           │\n")
-	msg.WriteString("├──────────────────┼────────┼────────────────────┤\n")
+
+	if hasSuite {
+		msg.WriteString("┌──────────────────┬──────────────────┬────────┬────────────────────┐\n")
+		msg.WriteString("│ Network          │ Suite            │ Status │ Next Run           │\n")
+		msg.WriteString("├──────────────────┼──────────────────┼────────┼────────────────────┤\n")
+	} else {
+		msg.WriteString("┌──────────────────┬────────┬────────────────────┐\n")
+		msg.WriteString("│ Network          │ Status │ Next Run           │\n")
+		msg.WriteString("├──────────────────┼────────┼────────────────────┤\n")
+	}
 
 	for _, alert := range alerts {
 		if alert.Network != networkName {
@@ -198,10 +216,23 @@ func buildSummaryTable(alerts []*hive.HiveSummaryAlert, networkName string) stri
 			}
 		}
 
-		msg.WriteString(fmt.Sprintf("│ %-16s │   %s   │ %-18s │\n", alert.Network, status, nextRun))
+		if hasSuite {
+			suite := alert.Suite
+			if suite == "" {
+				suite = "All"
+			}
+
+			msg.WriteString(fmt.Sprintf("│ %-16s │ %-16s │   %s   │ %-18s │\n", alert.Network, suite, status, nextRun))
+		} else {
+			msg.WriteString(fmt.Sprintf("│ %-16s │   %s   │ %-18s │\n", alert.Network, status, nextRun))
+		}
 	}
 
-	msg.WriteString("└──────────────────┴────────┴────────────────────┘\n```")
+	if hasSuite {
+		msg.WriteString("└──────────────────┴──────────────────┴────────┴────────────────────┘\n```")
+	} else {
+		msg.WriteString("└──────────────────┴────────┴────────────────────┘\n```")
+	}
 
 	return msg.String()
 }

--- a/pkg/discord/cmd/hive/run.go
+++ b/pkg/discord/cmd/hive/run.go
@@ -12,8 +12,18 @@ import (
 func (c *HiveCommand) handleRun(s *discordgo.Session, i *discordgo.InteractionCreate, cmd *discordgo.ApplicationCommandInteractionDataOption) {
 	var (
 		network = cmd.Options[0].StringValue()
+		suite   = ""
 		guildID = i.GuildID
 	)
+
+	// Extract the suite parameter if provided
+	for _, opt := range cmd.Options {
+		if opt.Name == optionNameSuite {
+			suite = opt.StringValue()
+
+			break
+		}
+	}
 
 	// Check if Hive is available for this network.
 	available, err := c.bot.GetHive().IsAvailable(context.Background(), network)
@@ -29,11 +39,17 @@ func (c *HiveCommand) handleRun(s *discordgo.Session, i *discordgo.InteractionCr
 		return
 	}
 
+	// Build the initial response message
+	initialMsg := fmt.Sprintf("🔄 Running Hive summary for **%s**", network)
+	if suite != "" {
+		initialMsg = fmt.Sprintf("🔄 Running Hive summary for **%s** (suite: %s)", network, suite)
+	}
+
 	// Now, respond that we're working on it.
 	if respondErr := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseChannelMessageWithSource,
 		Data: &discordgo.InteractionResponseData{
-			Content: fmt.Sprintf("🔄 Running Hive summary for **%s**...", network),
+			Content: initialMsg + "...",
 			Flags:   discordgo.MessageFlagsEphemeral,
 		},
 	}); respondErr != nil {
@@ -45,6 +61,7 @@ func (c *HiveCommand) handleRun(s *discordgo.Session, i *discordgo.InteractionCr
 	// Create a temporary alert for this run
 	alert := &hive.HiveSummaryAlert{
 		Network:        network,
+		Suite:          suite,
 		DiscordChannel: i.ChannelID,
 		DiscordGuildID: guildID,
 		Enabled:        true,
@@ -53,8 +70,13 @@ func (c *HiveCommand) handleRun(s *discordgo.Session, i *discordgo.InteractionCr
 	// Run the Hive summary check.
 	if runErr := c.RunHiveSummary(context.Background(), alert); runErr != nil {
 		// Edit the response to show the error.
+		errorMsg := fmt.Sprintf("❌ Failed to run Hive summary for **%s**", network)
+		if suite != "" {
+			errorMsg = fmt.Sprintf("❌ Failed to run Hive summary for **%s** (suite: %s)", network, suite)
+		}
+
 		if _, editErr := s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
-			Content: stringPtr(fmt.Sprintf("❌ Failed to run Hive summary for **%s**: %v", network, err)),
+			Content: stringPtr(fmt.Sprintf("%s: %v", errorMsg, runErr)),
 		}); editErr != nil {
 			c.log.WithError(editErr).Error("Failed to edit initial response")
 		}
@@ -65,8 +87,13 @@ func (c *HiveCommand) handleRun(s *discordgo.Session, i *discordgo.InteractionCr
 	}
 
 	// Edit the response to show success.
+	successMsg := fmt.Sprintf("✅ Hive summary for **%s** completed successfully", network)
+	if suite != "" {
+		successMsg = fmt.Sprintf("✅ Hive summary for **%s** (suite: %s) completed successfully", network, suite)
+	}
+
 	if _, err = s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
-		Content: stringPtr(fmt.Sprintf("✅ Hive summary for **%s** completed successfully", network)),
+		Content: stringPtr(successMsg),
 	}); err != nil {
 		c.log.WithError(err).Error("Failed to edit initial response")
 	}

--- a/pkg/discord/cmd/hive/summary.go
+++ b/pkg/discord/cmd/hive/summary.go
@@ -22,7 +22,7 @@ func (c *HiveCommand) sendHiveSummary(
 	session := c.bot.GetSession()
 
 	// Send the combined summary overview and test type breakdown in the main channel.
-	overviewEmbed := createCombinedOverviewEmbed(summary, prevSummary, results)
+	overviewEmbed := createCombinedOverviewEmbed(summary, prevSummary, results, alert.Suite)
 
 	// Create message send object.
 	messageSend := &discordgo.MessageSend{
@@ -57,6 +57,9 @@ func (c *HiveCommand) sendHiveSummary(
 
 	// Create a thread for the client details.
 	threadName := fmt.Sprintf("Hive Summary - %s", summary.Timestamp.Format(threadDateFormat))
+	if alert.Suite != "" {
+		threadName = fmt.Sprintf("Hive Summary (%s) - %s", alert.Suite, summary.Timestamp.Format(threadDateFormat))
+	}
 
 	thread, err := session.MessageThreadStartComplex(alert.DiscordChannel, mainMessage.ID, &discordgo.ThreadStart{
 		Name:                threadName,
@@ -261,7 +264,7 @@ func createClientEmbed(
 }
 
 // createCombinedOverviewEmbed creates an embed with the summary overview and test type breakdown.
-func createCombinedOverviewEmbed(summary *hive.SummaryResult, prevSummary *hive.SummaryResult, results []hive.TestResult) *discordgo.MessageEmbed {
+func createCombinedOverviewEmbed(summary *hive.SummaryResult, prevSummary *hive.SummaryResult, results []hive.TestResult, suite string) *discordgo.MessageEmbed {
 	// Format the timestamp in a user-friendly way using UTC.
 	lastUpdated := summary.Timestamp.UTC().Format("Mon, 2 Jan 2006")
 
@@ -357,8 +360,14 @@ func createCombinedOverviewEmbed(summary *hive.SummaryResult, prevSummary *hive.
 		})
 	}
 
+	// Create title with optional suite information
+	title := fmt.Sprintf("🐝 **Hive Summary - %s**", summary.Network)
+	if suite != "" {
+		title = fmt.Sprintf("🐝 **Hive Summary - %s (%s suite)**", summary.Network, suite)
+	}
+
 	return &discordgo.MessageEmbed{
-		Title:  fmt.Sprintf("🐝 **Hive Summary - %s**", summary.Network),
+		Title:  title,
 		Color:  0x3498DB,
 		Fields: fields,
 	}

--- a/pkg/discord/cmd/hive/summary.go
+++ b/pkg/discord/cmd/hive/summary.go
@@ -441,12 +441,8 @@ func createCombinedOverviewEmbed(summary *hive.SummaryResult, prevSummary *hive.
 	}
 
 	return &discordgo.MessageEmbed{
-		//Title:  title,
 		Color:  embedColor,
 		Fields: fields,
-		//Thumbnail: &discordgo.MessageEmbedThumbnail{
-		//	URL: "https://ethpandaops.io/img/hive-logo.png",
-		//},
 		Author: &discordgo.MessageEmbedAuthor{
 			Name:    title,
 			IconURL: "https://ethpandaops.io/img/hive-logo.png",

--- a/pkg/hive/types.go
+++ b/pkg/hive/types.go
@@ -45,6 +45,7 @@ type SummaryResult struct {
 // HiveSummaryAlert represents a Hive summary alert configuration.
 type HiveSummaryAlert struct {
 	Network        string    `json:"network"`
+	Suite          string    `json:"suite,omitempty"` // Optional suite filter - empty means all suites
 	DiscordChannel string    `json:"discordChannel"`
 	DiscordGuildID string    `json:"discordGuildId"`
 	Enabled        bool      `json:"enabled"`


### PR DESCRIPTION
- extend register, deregister, run, list and summary flows
- add suite autocomplete that depends on selected network
- store suite-specific results under dedicated S3 paths
- update embed titles and thread names to show suite when set