### PR TITLE
chore: bump Go from 1.26.0 to 1.26.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ethpandaops/panda-pulse
 
-go 1.26.0
+go 1.26.1
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.1


### PR DESCRIPTION
## Summary
- Bumped Go version directive in `go.mod` from 1.26.0 to 1.26.1
- Ran `go mod tidy` (no changes to `go.sum`) and verified compilation with `go build ./...`
- This bumps to the latest stable Go release

## Files Modified
- `go.mod`

🤖 Generated with [Claude Code](https://claude.com/claude-code)