### PR TITLE
fix: remove unused nolint:gosec directives

### DIFF
--- a/pkg/cartographoor/service.go
+++ b/pkg/cartographoor/service.go
@@ -215,7 +215,7 @@ func (s *Service) fetchAndUpdateData(ctx context.Context) error {
 		return fmt.Errorf("failed to create request: %w", err)
 	}
 
-	resp, err := s.httpClient.Do(req) //nolint:gosec // URL is from trusted configuration
+	resp, err := s.httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to fetch data: %w", err)
 	}

--- a/pkg/discord/cmd/build/trigger.go
+++ b/pkg/discord/cmd/build/trigger.go
@@ -294,7 +294,7 @@ func (c *BuildCommand) triggerWorkflow(buildTarget, repository, ref, dockerTag s
 	req.Header.Set("Content-Type", "application/json")
 
 	// Use the HTTP client
-	resp, err := c.httpClient.Do(req) //nolint:gosec // URL is from trusted configuration
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("failed to send request: %w", err)
 	}

--- a/pkg/discord/cmd/build/workflow_fetcher.go
+++ b/pkg/discord/cmd/build/workflow_fetcher.go
@@ -254,7 +254,7 @@ func (wf *WorkflowFetcher) getWorkflowFiles() ([]GitHubFile, error) {
 	req.Header.Set("Accept", "application/vnd.github.v3+json")
 	req.Header.Set("Authorization", "Bearer "+wf.githubToken)
 
-	resp, err := wf.httpClient.Do(req) //nolint:gosec // URL is from trusted configuration
+	resp, err := wf.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch workflow files: %w", err)
 	}
@@ -281,7 +281,7 @@ func (wf *WorkflowFetcher) parseWorkflow(downloadURL, workflowName string) (Work
 
 	req.Header.Set("Authorization", "Bearer "+wf.githubToken)
 
-	resp, err := wf.httpClient.Do(req) //nolint:gosec // URL is from trusted configuration
+	resp, err := wf.httpClient.Do(req)
 	if err != nil {
 		return WorkflowInfo{}, fmt.Errorf("failed to fetch workflow content: %w", err)
 	}

--- a/pkg/discord/cmd/hive/trigger.go
+++ b/pkg/discord/cmd/hive/trigger.go
@@ -172,7 +172,7 @@ func (c *HiveCommand) triggerHiveWorkflow(
 	req.Header.Set("Authorization", "Bearer "+c.githubToken)
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := c.httpClient.Do(req) //nolint:gosec // URL is from trusted configuration
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to send request: %w", err)
 	}

--- a/pkg/hive/hive.go
+++ b/pkg/hive/hive.go
@@ -180,7 +180,7 @@ func (h *hive) IsAvailable(ctx context.Context, network string) (bool, error) {
 		return false, fmt.Errorf("failed to create request: %w", err)
 	}
 
-	resp, err := h.httpClient.Do(req) //nolint:gosec // URL is from trusted configuration //nolint:gosec // URL is from trusted configuration
+	resp, err := h.httpClient.Do(req)
 	if err != nil {
 		// If the request fails, we assume Hive is not available.
 		return false, nil
@@ -228,7 +228,7 @@ func (h *hive) FetchAvailableNetworks(ctx context.Context) ([]string, error) {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
-	resp, err := h.httpClient.Do(req) //nolint:gosec // URL is from trusted configuration
+	resp, err := h.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch discovery: %w", err)
 	}
@@ -275,7 +275,7 @@ func (h *hive) FetchAvailableSuites(ctx context.Context, network string) ([]stri
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
-	resp, err := h.httpClient.Do(req) //nolint:gosec // URL is from trusted configuration
+	resp, err := h.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch test results: %w", err)
 	}
@@ -340,7 +340,7 @@ func (h *hive) FetchTestResults(ctx context.Context, network string, suiteFilter
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
-	resp, err := h.httpClient.Do(req) //nolint:gosec // URL is from trusted configuration
+	resp, err := h.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch test results: %w", err)
 	}


### PR DESCRIPTION
## Summary
- Removed 8 unused `//nolint:gosec` directives across 5 files that were flagged as `nolintlint` violations
- The directives were unnecessary because `httpClient.Do()` calls don't trigger gosec warnings when using a pre-configured HTTP client
- No functional changes — lint fixes only

## Files Changed
- `pkg/cartographoor/service.go`
- `pkg/discord/cmd/build/trigger.go`
- `pkg/discord/cmd/build/workflow_fetcher.go`
- `pkg/discord/cmd/hive/trigger.go`
- `pkg/hive/hive.go`

## Acceptance Criteria
- [x] `golangci-lint run ./...` passes with zero issues using the project's config
- [x] No functional changes — only lint fixes

## Review Summary
Removed 8 unused `//nolint:gosec` directives across 5 files (nolintlint violations). The directives were unnecessary because `httpClient.Do()` calls don't trigger gosec warnings when using a pre-configured HTTP client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)