### PR TITLE
feat(discord/build): DM invoker when their /build completes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.98.0
 	github.com/bwmarrin/discordgo v0.29.0
 	github.com/chromedp/chromedp v0.15.1
+	github.com/google/uuid v1.6.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/sirupsen/logrus v1.9.4
@@ -64,7 +65,6 @@ require (
 	github.com/gobwas/httphead v0.1.0 // indirect
 	github.com/gobwas/pool v0.2.1 // indirect
 	github.com/gobwas/ws v1.4.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/pkg/discord/bot.go
+++ b/pkg/discord/bot.go
@@ -143,6 +143,20 @@ func (b *DiscordBot) Start(ctx context.Context) error {
 		}
 	}
 
+	// Start background tasks owned by commands (e.g. build watcher DM poller).
+	for _, cmd := range b.commands {
+		starter, ok := cmd.(interface {
+			Start(context.Context) error
+		})
+		if !ok {
+			continue
+		}
+
+		if err := starter.Start(ctx); err != nil {
+			return fmt.Errorf("failed to start command %s: %w", cmd.Name(), err)
+		}
+	}
+
 	// If we have any existing monitor alerts configured, schedule them.
 	if err := b.scheduleExistingAlerts(); err != nil {
 		return fmt.Errorf("failed to schedule existing alerts: %w", err)

--- a/pkg/discord/cmd/build/command.go
+++ b/pkg/discord/cmd/build/command.go
@@ -1,6 +1,7 @@
 package build
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -30,6 +31,7 @@ type BuildCommand struct {
 	githubToken        string
 	httpClient         *http.Client
 	workflowFetcher    *WorkflowFetcher
+	watcher            *BuildWatcher
 	guildRegistrations map[string]string // Maps guild ID to registered command ID for updates
 }
 
@@ -41,7 +43,15 @@ func NewBuildCommand(log *logrus.Logger, bot common.BotContext, githubToken stri
 		githubToken:     githubToken,
 		httpClient:      client,
 		workflowFetcher: NewWorkflowFetcher(client, githubToken, log, bot),
+		watcher:         NewBuildWatcher(log, bot.GetSession(), client, githubToken),
 	}
+}
+
+// Start starts background tasks owned by the command.
+func (c *BuildCommand) Start(ctx context.Context) error {
+	c.watcher.Start(ctx)
+
+	return nil
 }
 
 // Name returns the name of the command.

--- a/pkg/discord/cmd/build/trigger.go
+++ b/pkg/discord/cmd/build/trigger.go
@@ -1,6 +1,7 @@
 package build
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -8,6 +9,7 @@ import (
 	"time"
 
 	"github.com/bwmarrin/discordgo"
+	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
 )
 
@@ -159,8 +161,12 @@ func (c *BuildCommand) handleBuild(s *discordgo.Session, i *discordgo.Interactio
 		buildArgs = c.GetDefaultBuildArgs(targetName)
 	}
 
+	// Generate a correlation ID so we can locate the resulting workflow run and
+	// DM the invoker when it finishes.
+	correlationID := uuid.NewString()
+
 	// Trigger the workflow.
-	workflowURL, err := c.triggerWorkflow(targetName, repository, ref, dockerTag, buildArgs)
+	workflowURL, err := c.triggerWorkflow(targetName, repository, ref, dockerTag, buildArgs, correlationID)
 	if err != nil {
 		if _, interactionErr := s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
 			Content: new(fmt.Sprintf("❌ Failed to trigger build for **%s**: %s", targetDisplayName, err)),
@@ -169,6 +175,26 @@ func (c *BuildCommand) handleBuild(s *discordgo.Session, i *discordgo.Interactio
 		}
 
 		return nil // Already handled error by editing message.
+	}
+
+	// Kick off an asynchronous claim so we can DM the invoker on completion.
+	// Best-effort: if we can't determine the user or the run never surfaces,
+	// the trigger itself has already succeeded.
+	if userID := interactionUserID(i); userID != "" {
+		workflowFile := fmt.Sprintf("build-push-%s.yml", getClientToWorkflowName(targetName))
+
+		go func() {
+			claimCtx, cancel := context.WithTimeout(context.Background(), claimTimeout)
+			defer cancel()
+
+			if claimErr := c.watcher.Claim(claimCtx, userID, targetDisplayName, workflowFile, correlationID, workflowURL); claimErr != nil {
+				c.log.WithError(claimErr).WithFields(logrus.Fields{
+					"workflow":       workflowFile,
+					"correlation_id": correlationID,
+					"user":           userID,
+				}).Warn("Failed to claim build run for completion DM")
+			}
+		}()
 	}
 
 	// Create success embed.
@@ -249,7 +275,7 @@ func (c *BuildCommand) handleBuild(s *discordgo.Session, i *discordgo.Interactio
 }
 
 // triggerWorkflow triggers the GitHub workflow for the given build target.
-func (c *BuildCommand) triggerWorkflow(buildTarget, repository, ref, dockerTag string, buildArgs string) (string, error) {
+func (c *BuildCommand) triggerWorkflow(buildTarget, repository, ref, dockerTag, buildArgs, correlationID string) (string, error) {
 	// Prepare the workflow inputs.
 	inputs := map[string]any{
 		"repository": repository,
@@ -262,6 +288,10 @@ func (c *BuildCommand) triggerWorkflow(buildTarget, repository, ref, dockerTag s
 
 	if buildArgs != "" {
 		inputs["build_args"] = buildArgs
+	}
+
+	if correlationID != "" {
+		inputs["correlation_id"] = correlationID
 	}
 
 	body := map[string]any{
@@ -306,4 +336,22 @@ func (c *BuildCommand) triggerWorkflow(buildTarget, repository, ref, dockerTag s
 	}
 
 	return fmt.Sprintf("https://github.com/%s/actions/workflows/build-push-%s.yml", DefaultRepository, workflowName), nil
+}
+
+// interactionUserID extracts the invoking user's Discord ID from an interaction,
+// handling both guild and DM contexts.
+func interactionUserID(i *discordgo.InteractionCreate) string {
+	if i == nil {
+		return ""
+	}
+
+	if i.Member != nil && i.Member.User != nil {
+		return i.Member.User.ID
+	}
+
+	if i.User != nil {
+		return i.User.ID
+	}
+
+	return ""
 }

--- a/pkg/discord/cmd/build/watcher.go
+++ b/pkg/discord/cmd/build/watcher.go
@@ -1,0 +1,346 @@
+package build
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	// pollInterval is how often we check GitHub for status changes of tracked runs.
+	pollInterval = 30 * time.Second
+	// claimTimeout is how long we keep polling for the run ID after a dispatch.
+	claimTimeout = 90 * time.Second
+	// claimPollInterval is how often we poll the runs list while claiming.
+	claimPollInterval = 2 * time.Second
+	// runTimeout is an upper bound after which we stop watching a build.
+	runTimeout = 3 * time.Hour
+)
+
+// trackedBuild is a dispatched build we're watching for completion.
+type trackedBuild struct {
+	userID        string
+	targetDisplay string
+	workflowFile  string
+	correlationID string
+	runID         int64
+	htmlURL       string
+	dispatchedAt  time.Time
+}
+
+// workflowRun is the subset of the GitHub workflow run payload we use.
+//
+//nolint:tagliatelle // Github defined structure.
+type workflowRun struct {
+	ID           int64  `json:"id"`
+	Name         string `json:"name"`
+	DisplayTitle string `json:"display_title"`
+	Status       string `json:"status"`
+	Conclusion   string `json:"conclusion"`
+	HTMLURL      string `json:"html_url"`
+}
+
+// workflowRunsResponse wraps the list-runs endpoint response.
+//
+//nolint:tagliatelle // Github defined structure.
+type workflowRunsResponse struct {
+	WorkflowRuns []workflowRun `json:"workflow_runs"`
+}
+
+// BuildWatcher tracks dispatched builds and DMs the invoker on completion.
+type BuildWatcher struct {
+	log         logrus.FieldLogger
+	session     *discordgo.Session
+	httpClient  *http.Client
+	githubToken string
+
+	mu     sync.Mutex
+	tracks map[int64]*trackedBuild
+
+	wg sync.WaitGroup
+}
+
+// NewBuildWatcher creates a new BuildWatcher.
+func NewBuildWatcher(log logrus.FieldLogger, session *discordgo.Session, client *http.Client, githubToken string) *BuildWatcher {
+	return &BuildWatcher{
+		log:         log.WithField("component", "build/watcher"),
+		session:     session,
+		httpClient:  client,
+		githubToken: githubToken,
+		tracks:      make(map[int64]*trackedBuild, 8),
+	}
+}
+
+// Start launches the poller goroutine. The goroutine exits when ctx is cancelled.
+func (w *BuildWatcher) Start(ctx context.Context) {
+	w.wg.Add(1)
+
+	go w.pollLoop(ctx)
+}
+
+// Wait blocks until the poller goroutine has exited.
+func (w *BuildWatcher) Wait() {
+	w.wg.Wait()
+}
+
+// Claim finds the workflow_dispatch run for the given workflowFile whose
+// run-name contains correlationID, and starts tracking it for completion
+// notifications.
+func (w *BuildWatcher) Claim(ctx context.Context, userID, targetDisplay, workflowFile, correlationID, htmlURL string) error {
+	if correlationID == "" {
+		return fmt.Errorf("correlation id is required")
+	}
+
+	claimCtx, cancel := context.WithTimeout(ctx, claimTimeout)
+	defer cancel()
+
+	ticker := time.NewTicker(claimPollInterval)
+	defer ticker.Stop()
+
+	for {
+		run, err := w.findRunByCorrelation(claimCtx, workflowFile, correlationID)
+		if err != nil {
+			w.log.WithError(err).WithField("workflow", workflowFile).Debug("Failed to list runs, retrying")
+		} else if run != nil {
+			w.track(run, userID, targetDisplay, workflowFile, correlationID, htmlURL)
+
+			return nil
+		}
+
+		select {
+		case <-claimCtx.Done():
+			return fmt.Errorf("timed out claiming run for %s (correlation %s)", workflowFile, correlationID)
+		case <-ticker.C:
+		}
+	}
+}
+
+func (w *BuildWatcher) track(run *workflowRun, userID, targetDisplay, workflowFile, correlationID, fallbackURL string) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if _, exists := w.tracks[run.ID]; exists {
+		return
+	}
+
+	htmlURL := run.HTMLURL
+	if htmlURL == "" {
+		htmlURL = fallbackURL
+	}
+
+	w.tracks[run.ID] = &trackedBuild{
+		userID:        userID,
+		targetDisplay: targetDisplay,
+		workflowFile:  workflowFile,
+		correlationID: correlationID,
+		runID:         run.ID,
+		htmlURL:       htmlURL,
+		dispatchedAt:  time.Now(),
+	}
+
+	w.log.WithFields(logrus.Fields{
+		"run_id":         run.ID,
+		"user":           userID,
+		"target":         targetDisplay,
+		"workflow":       workflowFile,
+		"correlation_id": correlationID,
+	}).Info("Tracking build for completion DM")
+}
+
+// findRunByCorrelation returns the workflow_dispatch run whose run-name
+// contains the given correlation ID, if any.
+func (w *BuildWatcher) findRunByCorrelation(ctx context.Context, workflowFile, correlationID string) (*workflowRun, error) {
+	url := fmt.Sprintf(
+		"https://api.github.com/repos/%s/actions/workflows/%s/runs?event=workflow_dispatch&per_page=20",
+		DefaultRepository, workflowFile,
+	)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	req.Header.Set("Authorization", "Bearer "+w.githubToken)
+
+	resp, err := w.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("list runs: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("list runs status %d", resp.StatusCode)
+	}
+
+	var body workflowRunsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return nil, fmt.Errorf("decode runs: %w", err)
+	}
+
+	for i := range body.WorkflowRuns {
+		run := body.WorkflowRuns[i]
+		if runHasCorrelation(run, correlationID) {
+			return &run, nil
+		}
+	}
+
+	return nil, nil //nolint:nilnil // no match yet is a normal retry signal.
+}
+
+func runHasCorrelation(run workflowRun, correlationID string) bool {
+	return strings.Contains(run.Name, correlationID) || strings.Contains(run.DisplayTitle, correlationID)
+}
+
+func (w *BuildWatcher) pollLoop(ctx context.Context) {
+	defer w.wg.Done()
+
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			w.tickOnce(ctx)
+		}
+	}
+}
+
+func (w *BuildWatcher) tickOnce(ctx context.Context) {
+	w.mu.Lock()
+
+	snapshot := make([]*trackedBuild, 0, len(w.tracks))
+	for _, b := range w.tracks {
+		snapshot = append(snapshot, b)
+	}
+
+	w.mu.Unlock()
+
+	for _, b := range snapshot {
+		if time.Since(b.dispatchedAt) > runTimeout {
+			w.notify(b, "timed_out")
+			w.untrack(b.runID)
+
+			continue
+		}
+
+		run, err := w.fetchRun(ctx, b.runID)
+		if err != nil {
+			w.log.WithError(err).WithField("run_id", b.runID).Warn("Failed to fetch run status")
+
+			continue
+		}
+
+		if run.Status != "completed" {
+			continue
+		}
+
+		if run.HTMLURL != "" {
+			b.htmlURL = run.HTMLURL
+		}
+
+		w.notify(b, run.Conclusion)
+		w.untrack(b.runID)
+	}
+}
+
+func (w *BuildWatcher) fetchRun(ctx context.Context, runID int64) (*workflowRun, error) {
+	url := fmt.Sprintf("https://api.github.com/repos/%s/actions/runs/%d", DefaultRepository, runID)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	req.Header.Set("Authorization", "Bearer "+w.githubToken)
+
+	resp, err := w.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("get run: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("get run status %d", resp.StatusCode)
+	}
+
+	var run workflowRun
+	if err := json.NewDecoder(resp.Body).Decode(&run); err != nil {
+		return nil, fmt.Errorf("decode run: %w", err)
+	}
+
+	return &run, nil
+}
+
+func (w *BuildWatcher) untrack(runID int64) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	delete(w.tracks, runID)
+}
+
+func (w *BuildWatcher) notify(b *trackedBuild, conclusion string) {
+	channel, err := w.session.UserChannelCreate(b.userID)
+	if err != nil {
+		w.log.WithError(err).WithField("user", b.userID).Warn("Failed to create DM channel")
+
+		return
+	}
+
+	embed := &discordgo.MessageEmbed{
+		Title: fmt.Sprintf("%s Build %s: %s", conclusionEmoji(conclusion), conclusionLabel(conclusion), b.targetDisplay),
+		Color: buildEmbedColor,
+		Fields: []*discordgo.MessageEmbedField{
+			{
+				Name:   "Run",
+				Value:  fmt.Sprintf("[View on GitHub](%s)", b.htmlURL),
+				Inline: false,
+			},
+			{
+				Name:   "Duration",
+				Value:  time.Since(b.dispatchedAt).Truncate(time.Second).String(),
+				Inline: true,
+			},
+		},
+		Timestamp: time.Now().Format(time.RFC3339),
+	}
+
+	if _, err := w.session.ChannelMessageSendEmbed(channel.ID, embed); err != nil {
+		w.log.WithError(err).WithField("user", b.userID).Warn("Failed to send build completion DM")
+	}
+}
+
+func conclusionEmoji(conclusion string) string {
+	switch conclusion {
+	case "success":
+		return "✅"
+	case "failure":
+		return "❌"
+	case "cancelled":
+		return "🚫"
+	case "timed_out":
+		return "⏱️"
+	case "action_required":
+		return "⚠️"
+	default:
+		return "ℹ️"
+	}
+}
+
+func conclusionLabel(conclusion string) string {
+	if conclusion == "" {
+		return "completed"
+	}
+
+	return conclusion
+}


### PR DESCRIPTION
## Summary

- Adds a `BuildWatcher` that tracks each dispatched `/build` in memory and DMs the invoking user on the bot when the workflow run finishes (success, failure, cancelled, timed out)
- Uses a UUID `correlation_id` passed to the workflow as a `workflow_dispatch` input, surfaced in `run-name`, so we can match the dispatch to the exact run without any `actor`/timing heuristics (all our dispatches share the same `ethpandaops` bot actor)
- No new storage — in-memory only. If the bot restarts mid-build, notifications for that build are lost, which is an accepted tradeoff for a nice-to-have

## Why

The existing `/build` command is fire-and-forget: it triggers the workflow, returns a link, and that's it. When you kick off several 20–40 minute image builds and switch to something else, you end up hitting refresh on the Actions tab. A DM when each one is done removes that friction.

## How it works

1. On dispatch, generate `uuid.NewString()` and pass it as the `correlation_id` input (and as part of the workflow body).
2. Start a goroutine that calls `BuildWatcher.Claim(...)` with a 90s timeout. Claim polls the workflow's runs list and looks for a run whose `name` / `display_title` contains the UUID.
3. Once claimed, a shared poll loop checks each tracked run every 30s via `GET /actions/runs/{id}` and, when `status == "completed"`, opens a DM channel with the invoker and sends an embed with the conclusion, GitHub link, and duration.

## Requires

Companion PR in `eth-client-docker-image-builder` that adds the `correlation_id` input to every `build-push-*.yml` and sets a matching `run-name:`:
https://github.com/ethpandaops/eth-client-docker-image-builder/pull/354

That must land first; without it, dispatches with `correlation_id` will get 422'd. (We could soften that by only sending the field behind a feature flag or retrying without it, but since the companion PR is trivial I'd rather just sequence the rollout.)

## Test plan

- [ ] Merge and deploy https://github.com/ethpandaops/eth-client-docker-image-builder/pull/354 first
- [ ] Trigger a `/build client-el` and confirm the bot sends you a DM on completion
- [ ] Trigger two builds of the same workflow back-to-back and verify each correlation ID ends up on the right run
- [ ] Kill a build mid-run via the GitHub UI and verify the DM says "cancelled"
- [ ] Confirm bot restart during an in-flight build silently drops the notification (expected) without crashing