### PR TITLE
feat(discord/build): one-shot reply, image links, copy + dropdown in DM

### DIFF
--- a/pkg/discord/bot.go
+++ b/pkg/discord/bot.go
@@ -3,6 +3,7 @@ package discord
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/bwmarrin/discordgo"
@@ -236,6 +237,38 @@ func (b *DiscordBot) handleInteraction(s *discordgo.Session, i *discordgo.Intera
 
 				return
 			}
+		}
+
+		return
+	}
+
+	// Route message component interactions (buttons, select menus) to the
+	// command that owns the custom_id. We expect the id to be prefixed with
+	// "<command>:" — e.g. "build:copy:…".
+	if i.Type == discordgo.InteractionMessageComponent {
+		customID := i.MessageComponentData().CustomID
+
+		idx := strings.Index(customID, ":")
+		if idx <= 0 {
+			return
+		}
+
+		name := customID[:idx]
+		for _, cmd := range b.commands {
+			if cmd.Name() != name {
+				continue
+			}
+
+			handler, ok := cmd.(interface {
+				HandleComponent(*discordgo.Session, *discordgo.InteractionCreate)
+			})
+			if !ok {
+				return
+			}
+
+			handler.HandleComponent(s, i)
+
+			return
 		}
 
 		return

--- a/pkg/discord/cmd/build/command.go
+++ b/pkg/discord/cmd/build/command.go
@@ -208,6 +208,13 @@ func (c *BuildCommand) UpdateChoices(session *discordgo.Session) error {
 	return nil
 }
 
+// HandleComponent handles button and select-menu interactions that originate
+// from the build completion DM. It's wired from bot.handleInteraction for any
+// component custom_id that starts with "build:".
+func (c *BuildCommand) HandleComponent(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	c.watcher.HandleComponent(s, i)
+}
+
 // Handle handles the /build command.
 func (c *BuildCommand) Handle(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	if i.Type == discordgo.InteractionApplicationCommandAutocomplete {

--- a/pkg/discord/cmd/build/image.go
+++ b/pkg/discord/cmd/build/image.go
@@ -1,0 +1,66 @@
+package build
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// dockerImage is a combined-arch docker image produced by a manifest job.
+type dockerImage struct {
+	Repository string // e.g. "ethpandaops/prysm-beacon-chain"
+	Tag        string // e.g. "stable" or "stable-minimal"
+	Variant    string // human label derived from manifest job name, e.g. "" or "beacon-minimal"
+}
+
+// Reference returns "repository:tag".
+func (i dockerImage) Reference() string {
+	return fmt.Sprintf("%s:%s", i.Repository, i.Tag)
+}
+
+// HubURL returns the Docker Hub tag page URL.
+func (i dockerImage) HubURL() string {
+	return fmt.Sprintf("https://hub.docker.com/r/%s/tags?name=%s", i.Repository, i.Tag)
+}
+
+// Label returns a short user-facing label for dropdown options.
+func (i dockerImage) Label() string {
+	if i.Variant == "" {
+		return i.Reference()
+	}
+
+	return fmt.Sprintf("%s (%s)", i.Reference(), i.Variant)
+}
+
+var (
+	dockerTagInvalidChars  = regexp.MustCompile(`[^a-zA-Z0-9._]`)
+	dockerTagLeadingDashes = regexp.MustCompile(`^-+`)
+)
+
+// computeBaseDockerTag mirrors the `docker-tag` composite action in
+// eth-client-docker-image-builder. Given the workflow inputs and the upstream
+// repo for this workflow, it returns the tag that `prepare.target_tag`
+// produces at runtime.
+func computeBaseDockerTag(repository, ref, dockerTagOverride, upstreamRepository string) string {
+	input := dockerTagOverride
+	if input == "" {
+		input = ref
+	}
+
+	if input == "" {
+		return ""
+	}
+
+	prefix := ""
+
+	if upstreamRepository != "" && repository != "" && dockerTagOverride == "" && repository != upstreamRepository {
+		if idx := strings.Index(repository, "/"); idx > 0 {
+			prefix = repository[:idx] + "-"
+		}
+	}
+
+	sanitized := dockerTagInvalidChars.ReplaceAllString(input, "-")
+	sanitized = dockerTagLeadingDashes.ReplaceAllString(sanitized, "")
+
+	return prefix + sanitized
+}

--- a/pkg/discord/cmd/build/trigger.go
+++ b/pkg/discord/cmd/build/trigger.go
@@ -16,6 +16,10 @@ import (
 const (
 	fallbackDefaultBranch = "main"
 	buildEmbedColor       = 0x7289DA
+	// inlineClaimTimeout is how long handleBuild waits for the run-id lookup
+	// before responding without a Run link. The background watcher keeps
+	// trying for the full claimTimeout and relinks the embed when it lands.
+	inlineClaimTimeout = 12 * time.Second
 )
 
 // handleBuild handles the build subcommands (client-cl, client-el, tool).
@@ -73,16 +77,16 @@ func (c *BuildCommand) handleBuild(s *discordgo.Session, i *discordgo.Interactio
 		}
 	}
 
-	// Send immediate response, discord requires an ACK with 3s, sometimes triggering
-	// the build can blow out, and then things will fall apart.
+	// Defer the ACK so we have up to 15 minutes to send the final embed.
+	// Discord requires an ACK within 3s; deferring buys us time to dispatch
+	// the workflow and inline-claim the run before showing anything.
 	if err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-		Type: discordgo.InteractionResponseChannelMessageWithSource,
+		Type: discordgo.InteractionResponseDeferredChannelMessageWithSource,
 		Data: &discordgo.InteractionResponseData{
-			Content: fmt.Sprintf("🔄 Triggering build for **%s**...", targetDisplayName),
-			Flags:   discordgo.MessageFlagsEphemeral,
+			Flags: discordgo.MessageFlagsEphemeral,
 		},
 	}); err != nil {
-		return fmt.Errorf("failed to send initial response: %w", err)
+		return fmt.Errorf("failed to send deferred ack: %w", err)
 	}
 
 	// Get optional parameters.
@@ -177,17 +181,102 @@ func (c *BuildCommand) handleBuild(s *discordgo.Session, i *discordgo.Interactio
 		return nil // Already handled error by editing message.
 	}
 
-	// Kick off an asynchronous claim so we can DM the invoker on completion.
-	// Best-effort: if we can't determine the user or the run never surfaces,
-	// the trigger itself has already succeeded.
-	if userID := interactionUserID(i); userID != "" {
-		workflowFile := fmt.Sprintf("build-push-%s.yml", getClientToWorkflowName(targetName))
+	// Build the claim request up-front; we'll attempt an inline claim before
+	// responding so the embed can include the run URL when GitHub is fast.
+	userID := interactionUserID(i)
 
+	workflowName := getClientToWorkflowName(targetName)
+	workflowFile := fmt.Sprintf("build-push-%s.yml", workflowName)
+
+	var (
+		upstreamRepo string
+		manifests    []ManifestInfo
+	)
+
+	if allWorkflows, wfErr := c.workflowFetcher.GetAllWorkflows(); wfErr == nil {
+		if workflow, exists := allWorkflows[workflowName]; exists {
+			upstreamRepo = workflow.UpstreamRepo
+			manifests = workflow.Manifests
+		}
+	}
+
+	claimReq := ClaimRequest{
+		UserID:          userID,
+		TargetDisplay:   targetDisplayName,
+		WorkflowFile:    workflowFile,
+		CorrelationID:   correlationID,
+		HTMLURL:         workflowURL,
+		RepositoryInput: repository,
+		RefInput:        ref,
+		DockerTagInput:  dockerTag,
+		UpstreamRepo:    upstreamRepo,
+		Manifests:       manifests,
+	}
+
+	// Try to resolve the run URL inline (short timeout). If GitHub is slow,
+	// we render without a link and let the background claim relink later.
+	var (
+		inlineRunURL  string
+		inlineClaimed bool
+	)
+
+	if userID != "" {
+		inlineCtx, inlineCancel := context.WithTimeout(context.Background(), inlineClaimTimeout)
+
+		runURL, claimErr := c.watcher.Claim(inlineCtx, claimReq)
+
+		inlineCancel()
+
+		if claimErr == nil {
+			inlineRunURL = runURL
+			inlineClaimed = true
+		} else {
+			c.log.WithError(claimErr).WithFields(logrus.Fields{
+				"workflow":       workflowFile,
+				"correlation_id": correlationID,
+			}).Debug("Inline claim timed out; falling back to background claim")
+		}
+	}
+
+	embed := buildTriggeredEmbed(triggeredEmbedInput{
+		targetName:        targetName,
+		targetDisplayName: targetDisplayName,
+		repository:        repository,
+		ref:               ref,
+		dockerTag:         dockerTag,
+		buildArgs:         buildArgs,
+		runURL:            inlineRunURL,
+		isClient:          isClient,
+		cartographoor:     c.bot.GetCartographoor(),
+	})
+
+	if _, err = s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
+		Content: new(""),
+		Embeds:  &[]*discordgo.MessageEmbed{embed},
+	}); err != nil {
+		return fmt.Errorf("failed to edit response: %w", err)
+	}
+
+	c.log.WithFields(logrus.Fields{
+		"workflow":     targetName,
+		"repository":   repository,
+		"ref":          ref,
+		"docker_tag":   dockerTag,
+		"build_args":   buildArgs,
+		"inline_claim": inlineClaimed,
+	}).Info("Build triggered")
+
+	// If the inline claim didn't land (timeout or unknown user), keep claiming
+	// in the background so the run still gets tracked for the completion DM.
+	// We deliberately do NOT edit the triggered message again — the inline
+	// embed is the user's single, final reply. They'll get the run URL via
+	// the completion DM when the build finishes.
+	if userID != "" && !inlineClaimed {
 		go func() {
 			claimCtx, cancel := context.WithTimeout(context.Background(), claimTimeout)
 			defer cancel()
 
-			if claimErr := c.watcher.Claim(claimCtx, userID, targetDisplayName, workflowFile, correlationID, workflowURL); claimErr != nil {
+			if _, claimErr := c.watcher.Claim(claimCtx, claimReq); claimErr != nil {
 				c.log.WithError(claimErr).WithFields(logrus.Fields{
 					"workflow":       workflowFile,
 					"correlation_id": correlationID,
@@ -197,81 +286,87 @@ func (c *BuildCommand) handleBuild(s *discordgo.Session, i *discordgo.Interactio
 		}()
 	}
 
-	// Create success embed.
+	return nil
+}
+
+// triggeredEmbedInput bundles the values used to render the
+// "Build Triggered" embed, including an optional run URL that is included as
+// a "Run" field only when non-empty.
+type triggeredEmbedInput struct {
+	targetName        string
+	targetDisplayName string
+	repository        string
+	ref               string
+	dockerTag         string
+	buildArgs         string
+	runURL            string
+	isClient          bool
+	cartographoor     cartographoorService
+}
+
+// cartographoorService captures the subset of *cartographoor.Service that
+// buildTriggeredEmbed needs, so the helper stays decoupled from the bot.
+type cartographoorService interface {
+	IsELClient(string) bool
+	IsCLClient(string) bool
+	GetClientLogo(string) string
+}
+
+func buildTriggeredEmbed(in triggeredEmbedInput) *discordgo.MessageEmbed {
 	embed := &discordgo.MessageEmbed{
-		Title: fmt.Sprintf("🏗️ Build Triggered: %s", targetDisplayName),
+		Title: fmt.Sprintf("🏗️ Build Triggered: %s", in.targetDisplayName),
 		Color: buildEmbedColor,
 		Fields: []*discordgo.MessageEmbedField{
 			{
 				Name:   "Repository",
-				Value:  fmt.Sprintf("`%s`", repository),
+				Value:  fmt.Sprintf("`%s`", in.repository),
 				Inline: true,
 			},
 			{
 				Name:   "Branch/Tag",
-				Value:  fmt.Sprintf("`%s`", ref),
+				Value:  fmt.Sprintf("`%s`", in.ref),
 				Inline: true,
 			},
-			{
-				Name:   "Workflow",
-				Value:  fmt.Sprintf("[View Build Status](%s)", workflowURL),
-				Inline: false,
-			},
 		},
-		URL:       workflowURL,
 		Timestamp: time.Now().Format(time.RFC3339),
 	}
 
-	// Add docker tag if specified.
-	if dockerTag != "" {
+	if in.runURL != "" {
+		embed.URL = in.runURL
+		embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
+			Name:   "Run",
+			Value:  fmt.Sprintf("[View on GitHub](%s)", in.runURL),
+			Inline: false,
+		})
+	}
+
+	if in.dockerTag != "" {
 		embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
 			Name:   "Docker Tag",
-			Value:  fmt.Sprintf("`%s`", dockerTag),
+			Value:  fmt.Sprintf("`%s`", in.dockerTag),
 			Inline: true,
 		})
 	}
 
-	// Add build args if specified.
-	if buildArgs != "" {
+	if in.buildArgs != "" {
 		embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
 			Name:   "Build Args",
-			Value:  fmt.Sprintf("`%s`", buildArgs),
+			Value:  fmt.Sprintf("`%s`", in.buildArgs),
 			Inline: true,
 		})
 	}
 
-	// Add thumbnail.
-	cartographoor := c.bot.GetCartographoor()
-	if isClient && (cartographoor.IsELClient(targetName) || cartographoor.IsCLClient(targetName)) {
-		if logo := cartographoor.GetClientLogo(targetName); logo != "" {
-			embed.Thumbnail = &discordgo.MessageEmbedThumbnail{
-				URL: logo,
-			}
+	if in.isClient && in.cartographoor != nil && (in.cartographoor.IsELClient(in.targetName) || in.cartographoor.IsCLClient(in.targetName)) {
+		if logo := in.cartographoor.GetClientLogo(in.targetName); logo != "" {
+			embed.Thumbnail = &discordgo.MessageEmbedThumbnail{URL: logo}
 		}
 	} else {
-		// Default logo for non-client workflows.
 		embed.Thumbnail = &discordgo.MessageEmbedThumbnail{
 			URL: "https://pbs.twimg.com/profile_images/1772523356123959296/e9mkwqVp_400x400.jpg",
 		}
 	}
 
-	// Edit message with success embed.
-	if _, err = s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
-		Content: new(""),
-		Embeds:  &[]*discordgo.MessageEmbed{embed},
-	}); err != nil {
-		return fmt.Errorf("failed to edit response: %w", err)
-	}
-
-	c.log.WithFields(logrus.Fields{
-		"workflow":   targetName,
-		"repository": repository,
-		"ref":        ref,
-		"docker_tag": dockerTag,
-		"build_args": buildArgs,
-	}).Info("Build triggered")
-
-	return nil
+	return embed
 }
 
 // triggerWorkflow triggers the GitHub workflow for the given build target.

--- a/pkg/discord/cmd/build/watcher.go
+++ b/pkg/discord/cmd/build/watcher.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -22,17 +23,50 @@ const (
 	claimPollInterval = 2 * time.Second
 	// runTimeout is an upper bound after which we stop watching a build.
 	runTimeout = 3 * time.Hour
+	// completedRetention is how long we keep a build's resolved images around so
+	// that Copy-button and dropdown interactions from the DM still work after the
+	// notification has been sent.
+	completedRetention = 2 * time.Hour
 )
+
+// ClaimRequest captures everything the watcher needs to resolve the set of
+// combined-arch images a build produces and DM the invoker on completion.
+type ClaimRequest struct {
+	UserID          string
+	TargetDisplay   string
+	WorkflowFile    string
+	CorrelationID   string
+	HTMLURL         string
+	RepositoryInput string
+	RefInput        string
+	DockerTagInput  string
+	UpstreamRepo    string
+	Manifests       []ManifestInfo
+}
 
 // trackedBuild is a dispatched build we're watching for completion.
 type trackedBuild struct {
-	userID        string
+	userID          string
+	targetDisplay   string
+	workflowFile    string
+	correlationID   string
+	runID           int64
+	htmlURL         string
+	dispatchedAt    time.Time
+	repositoryInput string
+	refInput        string
+	dockerTagInput  string
+	upstreamRepo    string
+	manifests       []ManifestInfo
+}
+
+// completedBuild retains the resolved image list for a completed run so the
+// DM's Copy button and dropdown can respond with the exact tags even after
+// the poller has untracked the run.
+type completedBuild struct {
 	targetDisplay string
-	workflowFile  string
-	correlationID string
-	runID         int64
-	htmlURL       string
-	dispatchedAt  time.Time
+	images        []dockerImage
+	expiresAt     time.Time
 }
 
 // workflowRun is the subset of the GitHub workflow run payload we use.
@@ -54,6 +88,18 @@ type workflowRunsResponse struct {
 	WorkflowRuns []workflowRun `json:"workflow_runs"`
 }
 
+// workflowJobResult is the subset of a workflow run job we use.
+type workflowJobResult struct {
+	Name       string `json:"name"`
+	Status     string `json:"status"`
+	Conclusion string `json:"conclusion"`
+}
+
+// workflowJobsResponse wraps the list-jobs endpoint response.
+type workflowJobsResponse struct {
+	Jobs []workflowJobResult `json:"jobs"`
+}
+
 // BuildWatcher tracks dispatched builds and DMs the invoker on completion.
 type BuildWatcher struct {
 	log         logrus.FieldLogger
@@ -61,8 +107,9 @@ type BuildWatcher struct {
 	httpClient  *http.Client
 	githubToken string
 
-	mu     sync.Mutex
-	tracks map[int64]*trackedBuild
+	mu        sync.Mutex
+	tracks    map[int64]*trackedBuild
+	completed map[int64]*completedBuild
 
 	wg sync.WaitGroup
 }
@@ -75,6 +122,7 @@ func NewBuildWatcher(log logrus.FieldLogger, session *discordgo.Session, client 
 		httpClient:  client,
 		githubToken: githubToken,
 		tracks:      make(map[int64]*trackedBuild, 8),
+		completed:   make(map[int64]*completedBuild, 8),
 	}
 }
 
@@ -90,12 +138,14 @@ func (w *BuildWatcher) Wait() {
 	w.wg.Wait()
 }
 
-// Claim finds the workflow_dispatch run for the given workflowFile whose
-// run-name contains correlationID, and starts tracking it for completion
-// notifications.
-func (w *BuildWatcher) Claim(ctx context.Context, userID, targetDisplay, workflowFile, correlationID, htmlURL string) error {
-	if correlationID == "" {
-		return fmt.Errorf("correlation id is required")
+// Claim finds the workflow_dispatch run matching the given correlation ID and
+// starts tracking it for completion notifications. The returned URL is the
+// run's html_url (or the dispatch fallback if GitHub didn't surface one),
+// suitable for editing the triggered message to point at the specific run
+// rather than the workflow file listing.
+func (w *BuildWatcher) Claim(ctx context.Context, req ClaimRequest) (string, error) {
+	if req.CorrelationID == "" {
+		return "", fmt.Errorf("correlation id is required")
 	}
 
 	claimCtx, cancel := context.WithTimeout(ctx, claimTimeout)
@@ -105,24 +155,29 @@ func (w *BuildWatcher) Claim(ctx context.Context, userID, targetDisplay, workflo
 	defer ticker.Stop()
 
 	for {
-		run, err := w.findRunByCorrelation(claimCtx, workflowFile, correlationID)
+		run, err := w.findRunByCorrelation(claimCtx, req.WorkflowFile, req.CorrelationID)
 		if err != nil {
-			w.log.WithError(err).WithField("workflow", workflowFile).Debug("Failed to list runs, retrying")
+			w.log.WithError(err).WithField("workflow", req.WorkflowFile).Debug("Failed to list runs, retrying")
 		} else if run != nil {
-			w.track(run, userID, targetDisplay, workflowFile, correlationID, htmlURL)
+			runURL := run.HTMLURL
+			if runURL == "" {
+				runURL = req.HTMLURL
+			}
 
-			return nil
+			w.track(run, req)
+
+			return runURL, nil
 		}
 
 		select {
 		case <-claimCtx.Done():
-			return fmt.Errorf("timed out claiming run for %s (correlation %s)", workflowFile, correlationID)
+			return "", fmt.Errorf("timed out claiming run for %s (correlation %s)", req.WorkflowFile, req.CorrelationID)
 		case <-ticker.C:
 		}
 	}
 }
 
-func (w *BuildWatcher) track(run *workflowRun, userID, targetDisplay, workflowFile, correlationID, fallbackURL string) {
+func (w *BuildWatcher) track(run *workflowRun, req ClaimRequest) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
@@ -132,25 +187,30 @@ func (w *BuildWatcher) track(run *workflowRun, userID, targetDisplay, workflowFi
 
 	htmlURL := run.HTMLURL
 	if htmlURL == "" {
-		htmlURL = fallbackURL
+		htmlURL = req.HTMLURL
 	}
 
 	w.tracks[run.ID] = &trackedBuild{
-		userID:        userID,
-		targetDisplay: targetDisplay,
-		workflowFile:  workflowFile,
-		correlationID: correlationID,
-		runID:         run.ID,
-		htmlURL:       htmlURL,
-		dispatchedAt:  time.Now(),
+		userID:          req.UserID,
+		targetDisplay:   req.TargetDisplay,
+		workflowFile:    req.WorkflowFile,
+		correlationID:   req.CorrelationID,
+		runID:           run.ID,
+		htmlURL:         htmlURL,
+		dispatchedAt:    time.Now(),
+		repositoryInput: req.RepositoryInput,
+		refInput:        req.RefInput,
+		dockerTagInput:  req.DockerTagInput,
+		upstreamRepo:    req.UpstreamRepo,
+		manifests:       req.Manifests,
 	}
 
 	w.log.WithFields(logrus.Fields{
 		"run_id":         run.ID,
-		"user":           userID,
-		"target":         targetDisplay,
-		"workflow":       workflowFile,
-		"correlation_id": correlationID,
+		"user":           req.UserID,
+		"target":         req.TargetDisplay,
+		"workflow":       req.WorkflowFile,
+		"correlation_id": req.CorrelationID,
 	}).Info("Tracking build for completion DM")
 }
 
@@ -227,8 +287,7 @@ func (w *BuildWatcher) tickOnce(ctx context.Context) {
 
 	for _, b := range snapshot {
 		if time.Since(b.dispatchedAt) > runTimeout {
-			w.notify(b, "timed_out")
-			w.untrack(b.runID)
+			w.finalize(ctx, b, "timed_out")
 
 			continue
 		}
@@ -248,9 +307,70 @@ func (w *BuildWatcher) tickOnce(ctx context.Context) {
 			b.htmlURL = run.HTMLURL
 		}
 
-		w.notify(b, run.Conclusion)
-		w.untrack(b.runID)
+		w.finalize(ctx, b, run.Conclusion)
 	}
+
+	w.sweepCompleted()
+}
+
+func (w *BuildWatcher) finalize(ctx context.Context, b *trackedBuild, conclusion string) {
+	images := w.resolveImages(ctx, b)
+
+	w.notify(b, conclusion, images)
+
+	w.mu.Lock()
+	delete(w.tracks, b.runID)
+
+	if len(images) > 0 {
+		w.completed[b.runID] = &completedBuild{
+			targetDisplay: b.targetDisplay,
+			images:        images,
+			expiresAt:     time.Now().Add(completedRetention),
+		}
+	}
+	w.mu.Unlock()
+}
+
+// resolveImages fetches the workflow run jobs and returns the combined-arch
+// images that correspond to manifest jobs which completed successfully.
+func (w *BuildWatcher) resolveImages(ctx context.Context, b *trackedBuild) []dockerImage {
+	if len(b.manifests) == 0 {
+		return nil
+	}
+
+	jobs, err := w.fetchJobs(ctx, b.runID)
+	if err != nil {
+		w.log.WithError(err).WithField("run_id", b.runID).Warn("Failed to fetch run jobs, skipping image resolution")
+
+		return nil
+	}
+
+	jobByName := make(map[string]workflowJobResult, len(jobs))
+	for _, j := range jobs {
+		jobByName[j.Name] = j
+	}
+
+	baseTag := computeBaseDockerTag(b.repositoryInput, b.refInput, b.dockerTagInput, b.upstreamRepo)
+	if baseTag == "" {
+		return nil
+	}
+
+	images := make([]dockerImage, 0, len(b.manifests))
+
+	for _, m := range b.manifests {
+		job, ok := jobByName[m.JobName]
+		if !ok || job.Conclusion != "success" {
+			continue
+		}
+
+		images = append(images, dockerImage{
+			Repository: m.Repository,
+			Tag:        baseTag + m.TagSuffix,
+			Variant:    m.Variant,
+		})
+	}
+
+	return images
 }
 
 func (w *BuildWatcher) fetchRun(ctx context.Context, runID int64) (*workflowRun, error) {
@@ -282,14 +402,67 @@ func (w *BuildWatcher) fetchRun(ctx context.Context, runID int64) (*workflowRun,
 	return &run, nil
 }
 
-func (w *BuildWatcher) untrack(runID int64) {
+func (w *BuildWatcher) fetchJobs(ctx context.Context, runID int64) ([]workflowJobResult, error) {
+	url := fmt.Sprintf("https://api.github.com/repos/%s/actions/runs/%d/jobs?per_page=100", DefaultRepository, runID)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	req.Header.Set("Authorization", "Bearer "+w.githubToken)
+
+	resp, err := w.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("list jobs: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("list jobs status %d", resp.StatusCode)
+	}
+
+	var body workflowJobsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return nil, fmt.Errorf("decode jobs: %w", err)
+	}
+
+	return body.Jobs, nil
+}
+
+func (w *BuildWatcher) sweepCompleted() {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
-	delete(w.tracks, runID)
+	now := time.Now()
+	for id, c := range w.completed {
+		if now.After(c.expiresAt) {
+			delete(w.completed, id)
+		}
+	}
 }
 
-func (w *BuildWatcher) notify(b *trackedBuild, conclusion string) {
+// lookupCompleted returns the retained images for a completed run, if any.
+func (w *BuildWatcher) lookupCompleted(runID int64) (*completedBuild, bool) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	c, ok := w.completed[runID]
+	if !ok {
+		return nil, false
+	}
+
+	if time.Now().After(c.expiresAt) {
+		delete(w.completed, runID)
+
+		return nil, false
+	}
+
+	return c, true
+}
+
+func (w *BuildWatcher) notify(b *trackedBuild, conclusion string, images []dockerImage) {
 	channel, err := w.session.UserChannelCreate(b.userID)
 	if err != nil {
 		w.log.WithError(err).WithField("user", b.userID).Warn("Failed to create DM channel")
@@ -297,6 +470,21 @@ func (w *BuildWatcher) notify(b *trackedBuild, conclusion string) {
 		return
 	}
 
+	embed := buildCompletionEmbed(b, conclusion, images)
+	components := buildCompletionComponents(b.runID, images)
+
+	send := &discordgo.MessageSend{
+		Embeds:     []*discordgo.MessageEmbed{embed},
+		Components: components,
+	}
+
+	if _, err := w.session.ChannelMessageSendComplex(channel.ID, send); err != nil {
+		w.log.WithError(err).WithField("user", b.userID).Warn("Failed to send build completion DM")
+	}
+}
+
+// buildCompletionEmbed builds the DM embed shown to the invoker.
+func buildCompletionEmbed(b *trackedBuild, conclusion string, images []dockerImage) *discordgo.MessageEmbed {
 	embed := &discordgo.MessageEmbed{
 		Title: fmt.Sprintf("%s Build %s: %s", conclusionEmoji(conclusion), conclusionLabel(conclusion), b.targetDisplay),
 		Color: buildEmbedColor,
@@ -315,8 +503,160 @@ func (w *BuildWatcher) notify(b *trackedBuild, conclusion string) {
 		Timestamp: time.Now().Format(time.RFC3339),
 	}
 
-	if _, err := w.session.ChannelMessageSendEmbed(channel.ID, embed); err != nil {
-		w.log.WithError(err).WithField("user", b.userID).Warn("Failed to send build completion DM")
+	if len(images) > 0 {
+		primary := images[0]
+		embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
+			Name:   "Image",
+			Value:  fmt.Sprintf("[`%s`](%s)", primary.Reference(), primary.HubURL()),
+			Inline: false,
+		})
+	}
+
+	return embed
+}
+
+// buildCompletionComponents returns the copy button + (optional) select menu
+// that accompany the DM.
+func buildCompletionComponents(runID int64, images []dockerImage) []discordgo.MessageComponent {
+	if len(images) == 0 {
+		return nil
+	}
+
+	components := make([]discordgo.MessageComponent, 0, 2)
+
+	components = append(components, discordgo.ActionsRow{
+		Components: []discordgo.MessageComponent{
+			discordgo.Button{
+				Label:    "Copy tag",
+				Style:    discordgo.PrimaryButton,
+				Emoji:    &discordgo.ComponentEmoji{Name: "📋"},
+				CustomID: fmt.Sprintf("build:copy:%d:0", runID),
+			},
+		},
+	})
+
+	if len(images) > 1 {
+		options := make([]discordgo.SelectMenuOption, 0, len(images))
+
+		for idx, img := range images {
+			description := img.Reference()
+			if len(description) > 100 {
+				description = description[:97] + "..."
+			}
+
+			label := img.Label()
+			if len(label) > 100 {
+				label = label[:97] + "..."
+			}
+
+			options = append(options, discordgo.SelectMenuOption{
+				Label:       label,
+				Value:       strconv.Itoa(idx),
+				Description: description,
+			})
+		}
+
+		components = append(components, discordgo.ActionsRow{
+			Components: []discordgo.MessageComponent{
+				discordgo.SelectMenu{
+					MenuType:    discordgo.StringSelectMenu,
+					CustomID:    fmt.Sprintf("build:sel:%d", runID),
+					Placeholder: "Show another image…",
+					Options:     options,
+				},
+			},
+		})
+	}
+
+	return components
+}
+
+// HandleComponent responds to component interactions dispatched from the DM.
+func (w *BuildWatcher) HandleComponent(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	if i.Type != discordgo.InteractionMessageComponent {
+		return
+	}
+
+	data := i.MessageComponentData()
+
+	runID, idx, ok := parseComponentID(data.CustomID, data.Values)
+	if !ok {
+		w.respondEphemeral(s, i, "Sorry, couldn't decode that interaction.")
+
+		return
+	}
+
+	completed, ok := w.lookupCompleted(runID)
+	if !ok {
+		w.respondEphemeral(s, i, "This build is no longer in cache — open the image on Docker Hub from the link above.")
+
+		return
+	}
+
+	if idx < 0 || idx >= len(completed.images) {
+		w.respondEphemeral(s, i, "Unknown image selection.")
+
+		return
+	}
+
+	img := completed.images[idx]
+	content := fmt.Sprintf("[`%s`](%s)\n```\n%s\n```", img.Reference(), img.HubURL(), img.Reference())
+
+	w.respondEphemeral(s, i, content)
+}
+
+// parseComponentID parses a custom_id produced by buildCompletionComponents.
+//
+//	build:copy:{runID}:{idx}   -> idx is encoded in the custom_id
+//	build:sel:{runID}          -> idx is taken from the selected value
+func parseComponentID(customID string, values []string) (int64, int, bool) {
+	parts := strings.Split(customID, ":")
+	if len(parts) < 3 || parts[0] != "build" {
+		return 0, 0, false
+	}
+
+	runID, err := strconv.ParseInt(parts[2], 10, 64)
+	if err != nil {
+		return 0, 0, false
+	}
+
+	switch parts[1] {
+	case "copy":
+		if len(parts) < 4 {
+			return 0, 0, false
+		}
+
+		idx, err := strconv.Atoi(parts[3])
+		if err != nil {
+			return 0, 0, false
+		}
+
+		return runID, idx, true
+	case "sel":
+		if len(values) == 0 {
+			return 0, 0, false
+		}
+
+		idx, err := strconv.Atoi(values[0])
+		if err != nil {
+			return 0, 0, false
+		}
+
+		return runID, idx, true
+	default:
+		return 0, 0, false
+	}
+}
+
+func (w *BuildWatcher) respondEphemeral(s *discordgo.Session, i *discordgo.InteractionCreate, content string) {
+	if err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{
+			Content: content,
+			Flags:   discordgo.MessageFlagsEphemeral,
+		},
+	}); err != nil {
+		w.log.WithError(err).Warn("Failed to respond to component interaction")
 	}
 }
 

--- a/pkg/discord/cmd/build/workflow_fetcher.go
+++ b/pkg/discord/cmd/build/workflow_fetcher.go
@@ -23,6 +23,16 @@ type WorkflowInfo struct {
 	Name         string
 	BuildArgs    string
 	HasBuildArgs bool
+	UpstreamRepo string         // upstream_repository passed to the docker-tag action
+	Manifests    []ManifestInfo // combined-arch manifest jobs, if the workflow follows the pattern
+}
+
+// ManifestInfo describes a manifest job that produces a combined-arch docker image.
+type ManifestInfo struct {
+	JobName    string // e.g. "manifest", "manifest-beacon-minimal"
+	Repository string // target_repository, e.g. "ethpandaops/prysm-beacon-chain"
+	TagSuffix  string // literal suffix after ${{ needs.prepare.outputs.target_tag }}, e.g. "" or "-minimal"
+	Variant    string // human label derived from the job name, e.g. "" or "beacon-minimal"
 }
 
 // GitHubFile represents a file from GitHub API.
@@ -59,6 +69,20 @@ type Workflow struct {
 			Inputs WorkflowInputs `yaml:"inputs"`
 		} `yaml:"workflow_dispatch"`
 	} `yaml:"on"`
+	Jobs map[string]WorkflowJob `yaml:"jobs"`
+}
+
+// WorkflowJob is the subset of a job definition we parse. Most fields are
+// intentionally omitted since we only care about step invocations of the
+// shared manifest and docker-tag composite actions.
+type WorkflowJob struct {
+	Steps []WorkflowStep `yaml:"steps"`
+}
+
+// WorkflowStep is the subset of a step we parse.
+type WorkflowStep struct {
+	Uses string         `yaml:"uses"`
+	With map[string]any `yaml:"with"`
 }
 
 // WorkflowFetcher handles fetching and caching workflow information.
@@ -300,6 +324,8 @@ func (wf *WorkflowFetcher) parseWorkflow(downloadURL, workflowName string) (Work
 		Branch:       inputs.Ref.Default,
 		Name:         workflowName,
 		HasBuildArgs: inputs.BuildArgs != nil,
+		UpstreamRepo: extractUpstreamRepository(workflow.Jobs),
+		Manifests:    extractManifests(workflow.Jobs),
 	}
 
 	// Extract default build args if present
@@ -319,4 +345,120 @@ func (wf *WorkflowFetcher) parseWorkflow(downloadURL, workflowName string) (Work
 	info.Name = displayName
 
 	return info, nil
+}
+
+const (
+	manifestActionSuffix = "/.github/actions/manifest"
+	dockerTagActionUses  = "./.github/actions/docker-tag"
+	tagExprMarker        = "needs.prepare.outputs.target_tag"
+)
+
+// extractUpstreamRepository returns the upstream_repository input passed to
+// the docker-tag composite action, if any.
+func extractUpstreamRepository(jobs map[string]WorkflowJob) string {
+	for _, job := range jobs {
+		for _, step := range job.Steps {
+			if step.Uses != dockerTagActionUses {
+				continue
+			}
+
+			if upstream, ok := stringFromWith(step.With, "upstream_repository"); ok {
+				return upstream
+			}
+		}
+	}
+
+	return ""
+}
+
+// extractManifests scans the workflow jobs for steps that invoke the manifest
+// composite action with a target_tag expression that is a literal suffix on
+// top of the base target_tag. It skips deploy/per-arch steps whose target_tag
+// embeds ${{ matrix.slug }} or similar dynamic expressions.
+func extractManifests(jobs map[string]WorkflowJob) []ManifestInfo {
+	manifests := make([]ManifestInfo, 0, len(jobs))
+
+	for jobName, job := range jobs {
+		for _, step := range job.Steps {
+			if !strings.HasSuffix(step.Uses, manifestActionSuffix) {
+				continue
+			}
+
+			repo, ok := stringFromWith(step.With, "target_repository")
+			if !ok || repo == "" {
+				continue
+			}
+
+			tagExpr, ok := stringFromWith(step.With, "target_tag")
+			if !ok {
+				continue
+			}
+
+			suffix, ok := findTagSuffix(tagExpr)
+			if !ok {
+				continue
+			}
+
+			manifests = append(manifests, ManifestInfo{
+				JobName:    jobName,
+				Repository: repo,
+				TagSuffix:  suffix,
+				Variant:    manifestVariant(jobName),
+			})
+		}
+	}
+
+	return manifests
+}
+
+// findTagSuffix returns the literal text that follows
+// ${{ needs.prepare.outputs.target_tag }} inside a target_tag expression. It
+// rejects expressions that still contain dynamic interpolations (such as
+// ${{ matrix.slug }}) after the marker — those are per-arch deploy tags.
+func findTagSuffix(expr string) (string, bool) {
+	idx := strings.Index(expr, tagExprMarker)
+	if idx < 0 {
+		return "", false
+	}
+
+	closeIdx := strings.Index(expr[idx:], "}}")
+	if closeIdx < 0 {
+		return "", false
+	}
+
+	suffix := expr[idx+closeIdx+2:]
+	if strings.Contains(suffix, "${{") {
+		return "", false
+	}
+
+	return suffix, true
+}
+
+// manifestVariant strips the leading "manifest" token from a manifest job
+// name to produce a short human label. "manifest" -> "", "manifest-beacon" ->
+// "beacon", "manifest-beacon-minimal" -> "beacon-minimal".
+func manifestVariant(jobName string) string {
+	trimmed := strings.TrimPrefix(jobName, "manifest")
+
+	return strings.TrimPrefix(trimmed, "-")
+}
+
+func stringFromWith(with map[string]any, key string) (string, bool) {
+	if with == nil {
+		return "", false
+	}
+
+	raw, ok := with[key]
+	if !ok {
+		return "", false
+	}
+
+	switch v := raw.(type) {
+	case string:
+		return v, true
+	case fmt.Stringer:
+		return v.String(), true
+	default:
+		return "", false
+	}
 }


### PR DESCRIPTION
## Summary

Reshapes both ends of the `/build` lifecycle:

**Trigger reply — single message.** The slash command now defers its ACK, dispatches the workflow, and races the run-id lookup (`correlation_id` matched against `run.name` / `display_title`) with a 12s inline budget. The user sees one final message:

- Inline claim landed → embed has a `Run` field linking to the specific run URL.
- Inline claim timed out → embed renders without that field. No second edit happens — the user gets the run URL via the completion DM later.

A background goroutine still runs in the timeout case so the run gets tracked for the completion DM.

**Completion DM — image-aware.** Parses each `build-push-*.yml` to enumerate `manifest*` jobs (the combined-arch images) and skips per-arch `deploy*` jobs. Mirrors the upstream `docker-tag` composite action's sanitization in Go to derive the exact tag for each manifest. After the run completes, fetches the run's jobs and includes only manifests whose conclusion is `success`.

The DM embed shows the primary image as a hyperlink to its Docker Hub tag page. Components:

- `📋 Copy tag` button → ephemeral reply with the tag in a code block (click-to-copy).
- When a build produces multiple combined images (e.g. prysm: beacon-chain + validator + their `-minimal` variants), a select menu lists them all.

**Component routing.** `bot.handleInteraction` now routes `InteractionMessageComponent` interactions to whichever command owns the `<command>:` prefix on the custom_id, via an optional `HandleComponent` method on the command.

The watcher retains resolved images per-run for 2h so Copy / dropdown interactions still work after the DM was sent.

Companion to the `correlation_id` input added on `eth-client-docker-image-builder`.

## Test plan

- [ ] `go build ./...`, `go test ./pkg/discord/...`, `golangci-lint run --new-from-rev=origin/master ./...` all clean
- [ ] Trigger `/build client-cl client:lighthouse docker_tag:test-pulse-pr` in a test guild — verify single-message reply, `Run` field present (typical) or absent (slow-claim path)
- [ ] Wait for completion → DM arrives with `lighthouse:test-pulse-pr` hyperlinked + Copy button
- [ ] Trigger `/build client-cl client:prysm docker_tag:test-pulse-pr` — verify select menu lists all 4 combined images (`prysm-beacon-chain[-minimal]`, `prysm-validator[-minimal]`)
- [ ] Click Copy and dropdown options — ephemeral reply contains the right tag
- [ ] Trigger a build that fails one manifest → only successful manifest images appear in the DM