### PR TITLE
feat(discord/build): surface ethrex in /build client-el

### DIFF
--- a/pkg/discord/cmd/build/utils.go
+++ b/pkg/discord/cmd/build/utils.go
@@ -7,6 +7,15 @@ import (
 	"github.com/ethpandaops/panda-pulse/pkg/discord/cmd/common"
 )
 
+// extraClientsByType lists clients that should appear in the build dropdowns
+// even though Cartographoor's remote data has not yet caught up. Entries are
+// only surfaced when a matching build-push-<client>.yml workflow exists in
+// the eth-client-docker-image-builder repo, so unknown additions silently
+// drop off rather than producing dead choices.
+var extraClientsByType = map[string][]string{
+	"execution": {"ethrex"},
+}
+
 // getAdditionalWorkflows returns workflow information, dynamically fetched from GitHub.
 func (c *BuildCommand) getAdditionalWorkflows() map[string]WorkflowInfo {
 	workflows, err := c.workflowFetcher.GetToolWorkflows()
@@ -39,6 +48,21 @@ func (c *BuildCommand) getClientWorkflows(clientType string) map[string]Workflow
 		clients = cartographoor.GetCLClients()
 	default:
 		return make(map[string]WorkflowInfo)
+	}
+
+	// Merge in clients we know about that Cartographoor hasn't published yet.
+	seen := make(map[string]struct{}, len(clients))
+	for _, name := range clients {
+		seen[name] = struct{}{}
+	}
+
+	for _, name := range extraClientsByType[clientType] {
+		if _, ok := seen[name]; ok {
+			continue
+		}
+
+		clients = append(clients, name)
+		seen[name] = struct{}{}
 	}
 
 	// Filter workflows to only include clients that exist in both Cartographoor and GitHub workflows.

--- a/pkg/discord/cmd/build/workflow_fetcher.go
+++ b/pkg/discord/cmd/build/workflow_fetcher.go
@@ -201,6 +201,15 @@ func (wf *WorkflowFetcher) GetToolWorkflows() (map[string]WorkflowInfo, error) {
 		knownWorkflows[workflowName] = true
 	}
 
+	// Add clients we know about that Cartographoor hasn't published yet so
+	// they don't leak into the tool list.
+	for _, clientList := range extraClientsByType {
+		for _, client := range clientList {
+			workflowName := wf.getClientToWorkflowName(client)
+			knownWorkflows[workflowName] = true
+		}
+	}
+
 	// Filter out known client workflows
 	toolWorkflows := make(map[string]WorkflowInfo)
 


### PR DESCRIPTION
## Summary
- Add a small local override (`extraClientsByType`) in the build command so `ethrex` shows up in the `/build client-el` dropdown even though Cartographoor's remote data doesn't list it yet.
- Inclusion is still gated on the workflow existing in `eth-client-docker-image-builder` (`build-push-ethrex.yml` — present), so unknown additions silently drop off rather than producing dead choices.
- Treat the extras as known clients in `GetToolWorkflows` so ethrex doesn't double-list under `/build tool`.

## Notes
- Until Cartographoor catches up, ethrex's display name falls back to `ethrex` and the triggered-build embed uses the default panda thumbnail (no logo). The right long-term fix is to add ethrex upstream in Cartographoor's `networks.json`; this PR is the local stop-gap.

## Test plan
- [ ] `/build client-el` shows `ethrex` as an option in Discord
- [ ] `/build tool` no longer lists `ethrex`
- [ ] Triggering `/build client-el client:ethrex` dispatches `build-push-ethrex.yml` and the inline embed renders without error
- [ ] Other EL clients (geth, reth, nethermind, besu, erigon, ethereumjs, nimbusel) still appear and dispatch correctly