### PR TITLE
fix: regression in /build perms

### DIFF
--- a/pkg/discord/bot.go
+++ b/pkg/discord/bot.go
@@ -315,9 +315,8 @@ func (b *DiscordBot) handleInteraction(s *discordgo.Session, i *discordgo.Intera
 			// Set last execution timestamp
 			b.metrics.SetLastCommandTimestamp(cmd.Name(), subcommand, float64(time.Now().Unix()))
 
-			// Skip permission check for commands with their own permission handling
-			isTrigger := len(data.Options) > 0 && data.Options[0].Name == "trigger"
-			if isTrigger && (cmd.Name() == "build" || cmd.Name() == "hive") {
+			// Skip permission check for commands with their own permission handling.
+			if commandSelfChecksPermission(cmd.Name(), &data) {
 				cmd.Handle(s, i)
 
 				// Record command execution time
@@ -542,4 +541,19 @@ func (b *DiscordBot) scheduleDiscordChoiceRefresh() error {
 	b.log.Info("Scheduled bot command refresh")
 
 	return nil
+}
+
+// commandSelfChecksPermission reports whether the named command performs its own
+// permission gating and should bypass the dispatcher's generic check. /build
+// applies its own permissive rule (any team-tagged user can trigger any build),
+// and /hive trigger has bespoke per-subcommand handling.
+func commandSelfChecksPermission(cmdName string, data *discordgo.ApplicationCommandInteractionData) bool {
+	switch cmdName {
+	case "build":
+		return true
+	case "hive":
+		return data != nil && len(data.Options) > 0 && data.Options[0].Name == "trigger"
+	default:
+		return false
+	}
 }

--- a/pkg/discord/bot_test.go
+++ b/pkg/discord/bot_test.go
@@ -1,0 +1,54 @@
+package discord
+
+import (
+	"testing"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommandSelfChecksPermission(t *testing.T) {
+	// optionsWith builds interaction data with a single top-level subcommand
+	// option name, mirroring how Discord shapes /<command> <subcommand> calls.
+	optionsWith := func(subcommand string) *discordgo.ApplicationCommandInteractionData {
+		return &discordgo.ApplicationCommandInteractionData{
+			Options: []*discordgo.ApplicationCommandInteractionDataOption{
+				{Name: subcommand},
+			},
+		}
+	}
+
+	tests := []struct {
+		name    string
+		cmdName string
+		data    *discordgo.ApplicationCommandInteractionData
+		want    bool
+	}{
+		// /build owns its own permission check for every subcommand. Regression
+		// guard: before the fix, only `trigger` was bypassed and the renamed
+		// `client-cl` / `client-el` / `tool` subcommands fell through to the
+		// strict per-client check, blocking e.g. a geth-tagged user from
+		// running /build client-cl.
+		{name: "build client-cl bypasses", cmdName: "build", data: optionsWith("client-cl"), want: true},
+		{name: "build client-el bypasses", cmdName: "build", data: optionsWith("client-el"), want: true},
+		{name: "build tool bypasses", cmdName: "build", data: optionsWith("tool"), want: true},
+		{name: "build with no options bypasses", cmdName: "build", data: &discordgo.ApplicationCommandInteractionData{}, want: true},
+
+		// /hive still uses the legacy `trigger` subcommand naming.
+		{name: "hive trigger bypasses", cmdName: "hive", data: optionsWith("trigger"), want: true},
+		{name: "hive non-trigger does not bypass", cmdName: "hive", data: optionsWith("summary"), want: false},
+		{name: "hive with no options does not bypass", cmdName: "hive", data: &discordgo.ApplicationCommandInteractionData{}, want: false},
+		{name: "hive with nil data does not bypass", cmdName: "hive", data: nil, want: false},
+
+		// Every other command goes through the dispatcher's generic permission check.
+		{name: "checks does not bypass", cmdName: "checks", data: optionsWith("run"), want: false},
+		{name: "mentions does not bypass", cmdName: "mentions", data: optionsWith("add"), want: false},
+		{name: "unknown command does not bypass", cmdName: "whatever", data: optionsWith("trigger"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, commandSelfChecksPermission(tt.cmdName, tt.data))
+		})
+	}
+}

--- a/pkg/discord/cmd/build/permission_test.go
+++ b/pkg/discord/cmd/build/permission_test.go
@@ -1,0 +1,92 @@
+package build
+
+import (
+	"testing"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/ethpandaops/panda-pulse/pkg/discord/cmd/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testGuildID = "guild-1"
+
+// newTestSession creates a discordgo session with state pre-populated with the given roles.
+func newTestSession(t *testing.T, roles []*discordgo.Role) *discordgo.Session {
+	t.Helper()
+
+	session, err := discordgo.New("Bot fake-token")
+	require.NoError(t, err)
+
+	session.StateEnabled = true
+	session.State = discordgo.NewState()
+
+	guild := &discordgo.Guild{
+		ID:    testGuildID,
+		Roles: roles,
+	}
+	require.NoError(t, session.State.GuildAdd(guild))
+
+	return session
+}
+
+// TestBuildHasPermission pins down the build command's intentionally-permissive
+// rule: any user with any team role (or admin role) can trigger a build for any
+// target, regardless of which client the build is for. This is the rule the
+// dispatcher in pkg/discord/bot.go defers to via commandSelfChecksPermission.
+func TestBuildHasPermission(t *testing.T) {
+	cfg := &common.RoleConfig{
+		AdminRoles: map[string]bool{
+			"ef":    true,
+			"admin": true,
+		},
+		ClientRoles: map[string][]string{
+			"lighthouse": {"sigmaprime", "lighthouse"},
+			"prysm":      {"prysmatic", "prysm"},
+			"geth":       {"geth"},
+			"reth":       {"reth"},
+		},
+	}
+
+	cmd := &BuildCommand{}
+
+	tests := []struct {
+		name     string
+		roleName string
+		want     bool
+	}{
+		// Regression guard: a geth-tagged user (EL client team) must be able
+		// to trigger any build — including CL clients like /build client-cl
+		// lighthouse. Before the dispatcher fix, the strict per-client check
+		// in common.HasPermission was rejecting these.
+		{name: "geth role allowed (EL team triggering anything)", roleName: "geth", want: true},
+		{name: "reth role allowed", roleName: "reth", want: true},
+		{name: "lighthouse role allowed (CL team triggering anything)", roleName: "lighthouse", want: true},
+		{name: "sigmaprime alias allowed", roleName: "sigmaprime", want: true},
+		{name: "case-insensitive role match", roleName: "GETH", want: true},
+
+		// Admin roles always pass.
+		{name: "admin role allowed", roleName: "admin", want: true},
+		{name: "ef admin role allowed", roleName: "ef", want: true},
+
+		// Users with no team or admin role are still rejected.
+		{name: "unrelated role denied", roleName: "random-role", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			roles := []*discordgo.Role{{ID: "role-1", Name: tt.roleName}}
+			session := newTestSession(t, roles)
+			member := &discordgo.Member{Roles: []string{"role-1"}}
+
+			assert.Equal(t, tt.want, cmd.hasPermission(member, session, testGuildID, cfg))
+		})
+	}
+
+	t.Run("member with no roles denied", func(t *testing.T) {
+		session := newTestSession(t, nil)
+		member := &discordgo.Member{Roles: []string{}}
+
+		assert.False(t, cmd.hasPermission(member, session, testGuildID, cfg))
+	})
+}


### PR DESCRIPTION
- `/build client-cl`, `/build client-el`, and `/build tool` were rejecting team-tagged users (e.g. a `geth`-tagged dev couldn't trigger `/build client-cl lighthouse`) with a permission-denied error.
- The dispatcher in `pkg/discord/bot.go` bypasses the generic permission check only when the subcommand name is `trigger` — but `[e1b4467](https://github.com/ethpandaops/panda-pulse/commit/e1b4467905e2d9462c680ad9492adc52297dccd1)` renamed build's subcommands to `client-cl`/`client-el`/`tool`. Requests fell through to `common.HasPermission`, which enforces a strict per-client role match and ignored the build command's own permissive rule (any team role -> any build).
- Extracted the bypass decision into `commandSelfChecksPermission` and now bypass the generic check for every `/build` subcommand. `/hive trigger` keeps its existing bypass.