### PR TITLE
refactor: use cartographoor client library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.102.0
 	github.com/bwmarrin/discordgo v0.29.0
 	github.com/chromedp/chromedp v0.15.1
+	github.com/ethpandaops/cartographoor v0.0.0-20260601034537-1072505afa69
 	github.com/google/uuid v1.6.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/robfig/cron/v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -79,6 +79,8 @@ github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/ebitengine/purego v0.10.0 h1:QIw4xfpWT6GWTzaW5XEKy3HXoqrJGx1ijYHzTF0/ISU=
 github.com/ebitengine/purego v0.10.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
+github.com/ethpandaops/cartographoor v0.0.0-20260601034537-1072505afa69 h1:uEp8rQZ9DFP+uRs9hxC3HQvSfu0KH4bCB5TXAfVWVTQ=
+github.com/ethpandaops/cartographoor v0.0.0-20260601034537-1072505afa69/go.mod h1:By1UZThVBtMHckTIPE4TuRWacAYLmoHaOpnhdcmADS0=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/go-json-experiment/json v0.0.0-20260214004413-d219187c3433 h1:vymEbVwYFP/L05h5TKQxvkXoKxNvTpjxYKdF1Nlwuao=

--- a/pkg/cartographoor/refresh_test.go
+++ b/pkg/cartographoor/refresh_test.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -145,15 +144,10 @@ func TestServiceRefresh(t *testing.T) {
 // MemoryProvider: its ticker re-fetches a changing HTTP source and our watcher
 // propagates the new data into the local snapshot, with no manual notification.
 //
-// It is opt-in because the provider enforces a 1-minute minimum refresh
-// interval, so the test must wait for a real tick (~60s). Run it with:
-//
-//	CARTOGRAPHOOR_E2E_REFRESH=1 go test ./pkg/cartographoor/... -run TestServiceRefreshEndToEnd
+// The provider enforces a 1-minute minimum refresh interval, so this test waits
+// for a real tick (~60s). It runs unconditionally so a broken refresh chain is
+// always caught.
 func TestServiceRefreshEndToEnd(t *testing.T) {
-	if os.Getenv("CARTOGRAPHOOR_E2E_REFRESH") == "" {
-		t.Skip("set CARTOGRAPHOOR_E2E_REFRESH=1 to run the ~60s end-to-end refresh test")
-	}
-
 	const (
 		initialBody = `{"networks":{"foo-devnet-0":{"name":"devnet-0","status":"active"}},"clients":{}}`
 		updatedBody = `{"networks":{"foo-devnet-0":{"name":"devnet-0","status":"active"},` +

--- a/pkg/cartographoor/refresh_test.go
+++ b/pkg/cartographoor/refresh_test.go
@@ -2,7 +2,12 @@ package cartographoor
 
 import (
 	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -134,4 +139,62 @@ func TestServiceRefresh(t *testing.T) {
 	}, 2*time.Second, 10*time.Millisecond, "snapshot should reflect provider refresh")
 
 	require.Equal(t, []string{"foo-devnet-0"}, svc.GetInactiveNetworks())
+}
+
+// TestServiceRefreshEndToEnd drives the full refresh chain through the *real*
+// MemoryProvider: its ticker re-fetches a changing HTTP source and our watcher
+// propagates the new data into the local snapshot, with no manual notification.
+//
+// It is opt-in because the provider enforces a 1-minute minimum refresh
+// interval, so the test must wait for a real tick (~60s). Run it with:
+//
+//	CARTOGRAPHOOR_E2E_REFRESH=1 go test ./pkg/cartographoor/... -run TestServiceRefreshEndToEnd
+func TestServiceRefreshEndToEnd(t *testing.T) {
+	if os.Getenv("CARTOGRAPHOOR_E2E_REFRESH") == "" {
+		t.Skip("set CARTOGRAPHOOR_E2E_REFRESH=1 to run the ~60s end-to-end refresh test")
+	}
+
+	const (
+		initialBody = `{"networks":{"foo-devnet-0":{"name":"devnet-0","status":"active"}},"clients":{}}`
+		updatedBody = `{"networks":{"foo-devnet-0":{"name":"devnet-0","status":"active"},` +
+			`"bar-devnet-1":{"name":"devnet-1","status":"active"}},"clients":{}}`
+	)
+
+	var fetches atomic.Int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		// First fetch is the initial blocking load; every fetch after that
+		// (driven by the provider's ticker) returns the expanded network set.
+		body := updatedBody
+		if fetches.Add(1) == 1 {
+			body = initialBody
+		}
+
+		_, _ = io.WriteString(w, body)
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+
+	svc, err := NewService(ctx, ServiceConfig{
+		SourceURL:       server.URL,
+		RefreshInterval: time.Minute, // the provider's minimum
+		Logger:          logrus.New(),
+	})
+	require.NoError(t, err)
+
+	svc.Start(ctx)
+	defer svc.Stop()
+
+	// Initial load: only the first devnet is present.
+	require.Equal(t, []string{"foo-devnet-0"}, svc.GetActiveNetworks())
+
+	// Wait for the ticker to fire a real re-fetch and the watcher to apply it.
+	require.Eventually(t, func() bool {
+		return len(svc.GetActiveNetworks()) == 2
+	}, 90*time.Second, time.Second, "ticker-driven refresh should surface the second devnet")
+
+	require.GreaterOrEqual(t, fetches.Load(), int32(2), "expected at least one ticker-driven re-fetch")
 }

--- a/pkg/cartographoor/refresh_test.go
+++ b/pkg/cartographoor/refresh_test.go
@@ -1,0 +1,137 @@
+package cartographoor
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ethpandaops/cartographoor/pkg/client"
+	"github.com/ethpandaops/cartographoor/pkg/discovery"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeProvider is a controllable client.Provider for exercising the Service's
+// refresh path without a real HTTP source or ticker.
+type fakeProvider struct {
+	mu       sync.RWMutex
+	networks map[string]discovery.Network
+	clients  map[string]discovery.ClientInfo
+	notifyCh chan struct{}
+}
+
+// Compile-time interface check.
+var _ client.Provider = (*fakeProvider)(nil)
+
+func newFakeProvider() *fakeProvider {
+	return &fakeProvider{
+		networks: make(map[string]discovery.Network),
+		clients:  make(map[string]discovery.ClientInfo),
+		notifyCh: make(chan struct{}, 1),
+	}
+}
+
+func (f *fakeProvider) setNetworks(networks map[string]discovery.Network) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.networks = networks
+}
+
+func (f *fakeProvider) notify() {
+	select {
+	case f.notifyCh <- struct{}{}:
+	default:
+	}
+}
+
+func (f *fakeProvider) Start(context.Context) error { return nil }
+func (f *fakeProvider) Stop() error                 { return nil }
+func (f *fakeProvider) Ready() bool                 { return true }
+func (f *fakeProvider) NotifyChannel() <-chan struct{} {
+	return f.notifyCh
+}
+
+func (f *fakeProvider) GetNetworks(context.Context) (map[string]discovery.Network, error) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
+	out := make(map[string]discovery.Network, len(f.networks))
+	for k, v := range f.networks {
+		out[k] = v
+	}
+
+	return out, nil
+}
+
+func (f *fakeProvider) GetClients(context.Context) (map[string]discovery.ClientInfo, error) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
+	out := make(map[string]discovery.ClientInfo, len(f.clients))
+	for k, v := range f.clients {
+		out[k] = v
+	}
+
+	return out, nil
+}
+
+func (f *fakeProvider) GetNetwork(context.Context, string) (discovery.Network, bool, error) {
+	return discovery.Network{}, false, nil
+}
+
+func (f *fakeProvider) GetActiveNetworks(context.Context) (map[string]discovery.Network, error) {
+	return map[string]discovery.Network{}, nil
+}
+
+func (f *fakeProvider) GetInactiveNetworks(context.Context) (map[string]discovery.Network, error) {
+	return map[string]discovery.Network{}, nil
+}
+
+func (f *fakeProvider) GetNetworksByStatus(context.Context, string) (map[string]discovery.Network, error) {
+	return map[string]discovery.Network{}, nil
+}
+
+func (f *fakeProvider) GetClient(context.Context, string) (discovery.ClientInfo, bool, error) {
+	return discovery.ClientInfo{}, false, nil
+}
+
+func (f *fakeProvider) GetClientsByType(context.Context, string) (map[string]discovery.ClientInfo, error) {
+	return map[string]discovery.ClientInfo{}, nil
+}
+
+// TestServiceRefresh verifies the Service updates its local snapshot when the
+// provider signals new data on its notify channel.
+func TestServiceRefresh(t *testing.T) {
+	ctx := context.Background()
+
+	fp := newFakeProvider()
+	fp.setNetworks(map[string]discovery.Network{
+		"foo-devnet-0": {Name: "devnet-0", Status: active},
+	})
+
+	svc, err := newService(ctx, logrus.New(), fp)
+	require.NoError(t, err)
+
+	svc.Start(ctx)
+	defer svc.Stop()
+
+	// Initial snapshot loaded by newService.
+	require.Equal(t, []string{"foo-devnet-0"}, svc.GetActiveNetworks())
+
+	// A refresh brings in a second active devnet and flips the first to inactive.
+	fp.setNetworks(map[string]discovery.Network{
+		"foo-devnet-0": {Name: "devnet-0", Status: "inactive"},
+		"bar-devnet-1": {Name: "devnet-1", Status: active},
+	})
+	fp.notify()
+
+	require.Eventually(t, func() bool {
+		active := svc.GetActiveNetworks()
+
+		return len(active) == 1 && active[0] == "bar-devnet-1"
+	}, 2*time.Second, 10*time.Millisecond, "snapshot should reflect provider refresh")
+
+	require.Equal(t, []string{"foo-devnet-0"}, svc.GetInactiveNetworks())
+}

--- a/pkg/cartographoor/service.go
+++ b/pkg/cartographoor/service.go
@@ -2,7 +2,6 @@ package cartographoor
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"sort"
@@ -10,123 +9,32 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ethpandaops/cartographoor/pkg/client"
+	"github.com/ethpandaops/cartographoor/pkg/discovery"
 	"github.com/ethpandaops/panda-pulse/pkg/clients"
 	"github.com/sirupsen/logrus"
 )
 
 const (
 	active                 = "active"
+	devnet                 = "devnet"
 	defaultRefreshInterval = 1 * time.Hour
 	defaultRequestTimeout  = 30 * time.Second
 )
 
-// Service provides access to cartographoor data with automatic updates from a remote source.
+// Service provides access to cartographoor data with automatic updates from a
+// remote source. It wraps the official cartographoor client, layering on the
+// devnet-only filtering and client-role lookups panda-pulse needs, while keeping
+// a local snapshot so callers can query synchronously without a context.
 type Service struct {
-	log           *logrus.Logger
-	sourceURL     string
-	refreshTicker *time.Ticker
-	httpClient    *http.Client
-	stopChan      chan struct{}
-	dataMu        sync.RWMutex
-	remoteData    *NetworksData
-}
+	log      *logrus.Logger
+	provider client.Provider
+	done     chan struct{}
+	wg       sync.WaitGroup
 
-// NetworksData represents the structure of the networks.json file.
-type NetworksData struct {
-	NetworkMetadata map[string]NetworkMetadata `json:"networkMetadata,omitempty"`
-	Networks        map[string]NetworkInfo     `json:"networks"`
-	Clients         map[string]ClientData      `json:"clients"`
-	LastUpdate      string                     `json:"lastUpdate,omitempty"`
-	Duration        float64                    `json:"duration,omitempty"`
-	Providers       []any                      `json:"providers,omitempty"`
-}
-
-// NetworkMetadata represents metadata about network types.
-type NetworkMetadata struct {
-	DisplayName string       `json:"displayName"`
-	Description string       `json:"description"`
-	Links       []Link       `json:"links"`
-	Image       string       `json:"image"`
-	Stats       NetworkStats `json:"stats"`
-}
-
-// Link represents a hyperlink with title and URL.
-type Link struct {
-	Title string `json:"title"`
-	URL   string `json:"url"`
-}
-
-// NetworkStats contains statistics about a network type.
-type NetworkStats struct {
-	TotalNetworks    int      `json:"totalNetworks"`
-	ActiveNetworks   int      `json:"activeNetworks"`
-	InactiveNetworks int      `json:"inactiveNetworks"`
-	NetworkNames     []string `json:"networkNames"`
-}
-
-// NetworkInfo represents information about a specific network.
-type NetworkInfo struct {
-	Name          string        `json:"name"`
-	Description   string        `json:"description,omitempty"`
-	Repository    string        `json:"repository,omitempty"`
-	Path          string        `json:"path,omitempty"`
-	URL           string        `json:"url,omitempty"`
-	Status        string        `json:"status"` // "active" or "inactive"
-	LastUpdated   string        `json:"lastUpdated,omitempty"`
-	ChainID       int64         `json:"chainId,omitempty"`
-	GenesisConfig any           `json:"genesisConfig,omitempty"`
-	ServiceURLs   ServiceURLs   `json:"serviceUrls"`
-	Images        NetworkImages `json:"images"`
-}
-
-// ClientData represents the structure of a client in the networks.json file.
-type ClientData struct {
-	Name          string `json:"name"`
-	DisplayName   string `json:"displayName"`
-	Repository    string `json:"repository"`
-	Type          string `json:"type"`
-	Branch        string `json:"branch"`
-	Logo          string `json:"logo"`
-	LatestVersion string `json:"latestVersion"`
-	WebsiteURL    string `json:"websiteUrl"`
-	DocsURL       string `json:"docsUrl"`
-}
-
-// ServiceURLs contains URLs to various services for a network.
-type ServiceURLs struct {
-	JSONRPC        string `json:"jsonRpc,omitempty"`
-	BeaconRPC      string `json:"beaconRpc,omitempty"`
-	Explorer       string `json:"explorer,omitempty"`
-	BeaconExplorer string `json:"beaconExplorer,omitempty"`
-	Forkmon        string `json:"forkmon,omitempty"`
-	Assertoor      string `json:"assertoor,omitempty"`
-	Dora           string `json:"dora,omitempty"`
-	CheckpointSync string `json:"checkpointSync,omitempty"`
-	Blobscan       string `json:"blobscan,omitempty"`
-	BlobArchive    string `json:"blobArchive,omitempty"`
-	Ethstats       string `json:"ethstats,omitempty"`
-	DevnetSpec     string `json:"devnetSpec,omitempty"`
-	Forky          string `json:"forky,omitempty"`
-	Tracoor        string `json:"tracoor,omitempty"`
-}
-
-// NetworkImages contains image information for a network.
-type NetworkImages struct {
-	URL     string        `json:"url,omitempty"`
-	Clients []ClientImage `json:"clients,omitempty"`
-	Tools   []ToolImage   `json:"tools,omitempty"`
-}
-
-// ClientImage represents a client docker image.
-type ClientImage struct {
-	Name    string `json:"name"`
-	Version string `json:"version"`
-}
-
-// ToolImage represents a tool docker image.
-type ToolImage struct {
-	Name    string `json:"name"`
-	Version string `json:"version"`
+	dataMu   sync.RWMutex
+	networks map[string]discovery.Network
+	clients  map[string]discovery.ClientInfo
 }
 
 // ServiceConfig contains the configuration for the cartographoor service.
@@ -137,143 +45,80 @@ type ServiceConfig struct {
 	HTTPClient      *http.Client
 }
 
-// NewService creates a new cartographoor service.
+// NewService creates a new cartographoor service and performs the initial
+// (blocking) data fetch. It returns an error if the initial fetch fails so the
+// caller can fail fast at startup.
 func NewService(ctx context.Context, config ServiceConfig) (*Service, error) {
-	if config.SourceURL == "" {
-		config.SourceURL = "https://ethpandaops-platform-production-cartographoor.ams3.cdn.digitaloceanspaces.com/networks.json"
+	if config.Logger == nil {
+		config.Logger = logrus.New()
 	}
 
 	if config.RefreshInterval == 0 {
 		config.RefreshInterval = defaultRefreshInterval
 	}
 
-	if config.Logger == nil {
-		config.Logger = logrus.New()
+	// An empty SourceURL falls back to the client's default production endpoint,
+	// which matches the URL panda-pulse used previously.
+	provider, err := client.NewMemoryProvider(client.Config{
+		SourceURL:       config.SourceURL,
+		RefreshInterval: config.RefreshInterval,
+		RequestTimeout:  defaultRequestTimeout,
+		HTTPClient:      config.HTTPClient,
+	}, config.Logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create cartographoor provider: %w", err)
 	}
 
-	httpClient := config.HTTPClient
-	if httpClient == nil {
-		httpClient = &http.Client{
-			Timeout: defaultRequestTimeout,
-		}
+	// Initial (blocking) fetch plus the provider's own background refresh loop.
+	if err := provider.Start(ctx); err != nil {
+		return nil, fmt.Errorf("failed to start cartographoor provider: %w", err)
 	}
 
-	service := &Service{
-		log:           config.Logger,
-		sourceURL:     config.SourceURL,
-		refreshTicker: time.NewTicker(config.RefreshInterval),
-		httpClient:    httpClient,
-		stopChan:      make(chan struct{}),
-	}
-
-	// Perform initial fetch
-	if err := service.fetchAndUpdateData(ctx); err != nil {
-		return nil, fmt.Errorf("initial data fetch failed: %w", err)
-	}
-
-	return service, nil
+	return newService(ctx, config.Logger, provider)
 }
 
-// Start begins the periodic refresh of cartographoor data.
+// newService wraps an already-started provider and loads the initial snapshot.
+// It is the injection seam used by tests to supply a controllable provider.
+func newService(ctx context.Context, log *logrus.Logger, provider client.Provider) (*Service, error) {
+	if log == nil {
+		log = logrus.New()
+	}
+
+	s := &Service{
+		log:      log,
+		provider: provider,
+		done:     make(chan struct{}),
+		networks: make(map[string]discovery.Network),
+		clients:  make(map[string]discovery.ClientInfo),
+	}
+
+	if err := s.rebuild(ctx); err != nil {
+		return nil, fmt.Errorf("failed to load initial cartographoor data: %w", err)
+	}
+
+	return s, nil
+}
+
+// Start begins watching the provider for updates, refreshing the local snapshot
+// whenever new data is fetched.
 func (s *Service) Start(ctx context.Context) {
-	go func() {
-		for {
-			select {
-			case <-s.refreshTicker.C:
-				if err := s.fetchAndUpdateData(ctx); err != nil {
-					s.log.WithError(err).Error("Failed to refresh cartographoor data")
-				}
-			case <-s.stopChan:
-				s.log.Info("Cartographoor service stopped")
-
-				return
-			case <-ctx.Done():
-				s.log.Info("Cartographoor service context done")
-
-				return
-			}
-		}
-	}()
+	s.wg.Go(func() {
+		s.watch(ctx)
+	})
 
 	s.log.Info("Cartographoor service started")
 }
 
-// Stop halts the periodic refresh of cartographoor data.
+// Stop halts the update watcher and the underlying provider.
 func (s *Service) Stop() {
-	s.refreshTicker.Stop()
+	close(s.done)
+	s.wg.Wait()
 
-	close(s.stopChan)
-}
-
-// fetchAndUpdateData retrieves the latest data from the remote source.
-func (s *Service) fetchAndUpdateData(ctx context.Context) error {
-	ctx, cancel := context.WithTimeout(ctx, defaultRequestTimeout)
-	defer cancel()
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.sourceURL, nil)
-	if err != nil {
-		return fmt.Errorf("failed to create request: %w", err)
+	if err := s.provider.Stop(); err != nil {
+		s.log.WithError(err).Warn("Error stopping cartographoor provider")
 	}
 
-	resp, err := s.httpClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("failed to fetch data: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
-	}
-
-	var data NetworksData
-	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return fmt.Errorf("failed to decode data: %w", err)
-	}
-
-	s.dataMu.Lock()
-	s.remoteData = &data
-	s.dataMu.Unlock()
-
-	// Count statistics for logging
-	var (
-		activeNetworksCount   = 0
-		inactiveNetworksCount = 0
-		consensusClientsCount = 0
-		executionClientsCount = 0
-		unknownClientsCount   = 0
-	)
-
-	for _, network := range data.Networks {
-		// We only want devnets, so make sure the name contains "devnet".
-		if network.Status == active && strings.Contains(network.Name, "devnet") {
-			activeNetworksCount++
-		} else {
-			inactiveNetworksCount++
-		}
-	}
-
-	for _, client := range data.Clients {
-		switch client.Type {
-		case string(clients.ClientTypeCL):
-			consensusClientsCount++
-		case string(clients.ClientTypeEL):
-			executionClientsCount++
-		default:
-			unknownClientsCount++
-		}
-	}
-
-	s.log.WithFields(logrus.Fields{
-		"networks_count":    len(data.Networks),
-		"active_networks":   activeNetworksCount,
-		"inactive_networks": inactiveNetworksCount,
-		"clients_count":     len(data.Clients),
-		"consensus_clients": consensusClientsCount,
-		"execution_clients": executionClientsCount,
-		"unknown_type":      unknownClientsCount,
-	}).Info("Cartographoor updated")
-
-	return nil
+	s.log.Info("Cartographoor service stopped")
 }
 
 // GetClientRepository returns the repository for a client.
@@ -281,12 +126,8 @@ func (s *Service) GetClientRepository(clientName string) string {
 	s.dataMu.RLock()
 	defer s.dataMu.RUnlock()
 
-	if s.remoteData == nil {
-		return ""
-	}
-
-	if client, ok := s.remoteData.Clients[clientName]; ok {
-		return client.Repository
+	if c, ok := s.clients[clientName]; ok {
+		return c.Repository
 	}
 
 	return ""
@@ -297,12 +138,8 @@ func (s *Service) GetClientBranch(clientName string) string {
 	s.dataMu.RLock()
 	defer s.dataMu.RUnlock()
 
-	if s.remoteData == nil {
-		return ""
-	}
-
-	if client, ok := s.remoteData.Clients[clientName]; ok {
-		return client.Branch
+	if c, ok := s.clients[clientName]; ok {
+		return c.Branch
 	}
 
 	return ""
@@ -313,12 +150,8 @@ func (s *Service) GetClientLogo(clientName string) string {
 	s.dataMu.RLock()
 	defer s.dataMu.RUnlock()
 
-	if s.remoteData == nil {
-		return ""
-	}
-
-	if client, ok := s.remoteData.Clients[clientName]; ok && client.Logo != "" {
-		return client.Logo
+	if c, ok := s.clients[clientName]; ok && c.Logo != "" {
+		return c.Logo
 	}
 
 	return ""
@@ -329,12 +162,8 @@ func (s *Service) GetClientLatestVersion(clientName string) string {
 	s.dataMu.RLock()
 	defer s.dataMu.RUnlock()
 
-	if s.remoteData == nil {
-		return ""
-	}
-
-	if client, ok := s.remoteData.Clients[clientName]; ok {
-		return client.LatestVersion
+	if c, ok := s.clients[clientName]; ok {
+		return c.LatestVersion
 	}
 
 	return ""
@@ -345,12 +174,8 @@ func (s *Service) GetClientWebsiteURL(clientName string) string {
 	s.dataMu.RLock()
 	defer s.dataMu.RUnlock()
 
-	if s.remoteData == nil {
-		return ""
-	}
-
-	if client, ok := s.remoteData.Clients[clientName]; ok {
-		return client.WebsiteURL
+	if c, ok := s.clients[clientName]; ok {
+		return c.WebsiteURL
 	}
 
 	return ""
@@ -361,12 +186,8 @@ func (s *Service) GetClientDocsURL(clientName string) string {
 	s.dataMu.RLock()
 	defer s.dataMu.RUnlock()
 
-	if s.remoteData == nil {
-		return ""
-	}
-
-	if client, ok := s.remoteData.Clients[clientName]; ok {
-		return client.DocsURL
+	if c, ok := s.clients[clientName]; ok {
+		return c.DocsURL
 	}
 
 	return ""
@@ -377,12 +198,8 @@ func (s *Service) IsCLClient(clientName string) bool {
 	s.dataMu.RLock()
 	defer s.dataMu.RUnlock()
 
-	if s.remoteData == nil {
-		return false
-	}
-
-	if client, ok := s.remoteData.Clients[clientName]; ok {
-		return client.Type == string(clients.ClientTypeCL)
+	if c, ok := s.clients[clientName]; ok {
+		return c.Type == string(clients.ClientTypeCL)
 	}
 
 	return false
@@ -393,12 +210,8 @@ func (s *Service) IsELClient(clientName string) bool {
 	s.dataMu.RLock()
 	defer s.dataMu.RUnlock()
 
-	if s.remoteData == nil {
-		return false
-	}
-
-	if client, ok := s.remoteData.Clients[clientName]; ok {
-		return client.Type == string(clients.ClientTypeEL)
+	if c, ok := s.clients[clientName]; ok {
+		return c.Type == string(clients.ClientTypeEL)
 	}
 
 	return false
@@ -409,12 +222,8 @@ func (s *Service) GetClientDisplayName(clientName string) string {
 	s.dataMu.RLock()
 	defer s.dataMu.RUnlock()
 
-	if s.remoteData == nil {
-		return clientName
-	}
-
-	if client, ok := s.remoteData.Clients[clientName]; ok && client.DisplayName != "" {
-		return client.DisplayName
+	if c, ok := s.clients[clientName]; ok && c.DisplayName != "" {
+		return c.DisplayName
 	}
 
 	return clientName
@@ -425,12 +234,8 @@ func (s *Service) GetClientType(clientName string) string {
 	s.dataMu.RLock()
 	defer s.dataMu.RUnlock()
 
-	if s.remoteData == nil {
-		return ""
-	}
-
-	if client, ok := s.remoteData.Clients[clientName]; ok {
-		return client.Type
+	if c, ok := s.clients[clientName]; ok {
+		return c.Type
 	}
 
 	return ""
@@ -438,42 +243,12 @@ func (s *Service) GetClientType(clientName string) string {
 
 // GetConsensusClients returns all consensus clients from the remote data.
 func (s *Service) GetConsensusClients() []string {
-	s.dataMu.RLock()
-	defer s.dataMu.RUnlock()
-
-	if s.remoteData == nil {
-		return []string{}
-	}
-
-	clientsList := make([]string, 0)
-
-	for name, client := range s.remoteData.Clients {
-		if client.Type == string(clients.ClientTypeCL) {
-			clientsList = append(clientsList, name)
-		}
-	}
-
-	return clientsList
+	return s.clientsOfType(clients.ClientTypeCL)
 }
 
 // GetExecutionClients returns all execution clients from the remote data.
 func (s *Service) GetExecutionClients() []string {
-	s.dataMu.RLock()
-	defer s.dataMu.RUnlock()
-
-	if s.remoteData == nil {
-		return []string{}
-	}
-
-	clientsList := make([]string, 0)
-
-	for name, client := range s.remoteData.Clients {
-		if client.Type == string(clients.ClientTypeEL) {
-			clientsList = append(clientsList, name)
-		}
-	}
-
-	return clientsList
+	return s.clientsOfType(clients.ClientTypeEL)
 }
 
 // GetAllClients returns all known client names.
@@ -481,139 +256,59 @@ func (s *Service) GetAllClients() []string {
 	s.dataMu.RLock()
 	defer s.dataMu.RUnlock()
 
-	if s.remoteData == nil {
-		return []string{}
-	}
-
-	clientsList := make([]string, 0, len(s.remoteData.Clients))
-	for name := range s.remoteData.Clients {
+	clientsList := make([]string, 0, len(s.clients))
+	for name := range s.clients {
 		clientsList = append(clientsList, name)
 	}
 
 	return clientsList
 }
 
-// GetActiveNetworks returns all active networks sorted alphabetically.
+// GetActiveNetworks returns all active devnets sorted alphabetically.
 func (s *Service) GetActiveNetworks() []string {
-	s.dataMu.RLock()
-	defer s.dataMu.RUnlock()
-
-	if s.remoteData == nil {
-		return []string{}
-	}
-
-	networks := make([]string, 0)
-
-	for key, network := range s.remoteData.Networks {
-		if network.Status == active && strings.Contains(key, "devnet") {
-			networks = append(networks, key)
-		}
-	}
-
-	sort.Strings(networks)
-
-	return networks
+	return s.devnetsMatching(func(n discovery.Network) bool {
+		return n.Status == active
+	})
 }
 
-// GetInactiveNetworks returns all inactive networks sorted alphabetically.
+// GetInactiveNetworks returns all inactive devnets sorted alphabetically.
 func (s *Service) GetInactiveNetworks() []string {
-	s.dataMu.RLock()
-	defer s.dataMu.RUnlock()
-
-	if s.remoteData == nil {
-		return []string{}
-	}
-
-	networks := make([]string, 0)
-
-	for key, network := range s.remoteData.Networks {
-		if network.Status != active && strings.Contains(key, "devnet") {
-			networks = append(networks, key)
-		}
-	}
-
-	sort.Strings(networks)
-
-	return networks
+	return s.devnetsMatching(func(n discovery.Network) bool {
+		return n.Status != active
+	})
 }
 
-// GetAllNetworks returns all networks regardless of status.
+// GetAllNetworks returns all devnets regardless of status, sorted alphabetically.
 func (s *Service) GetAllNetworks() []string {
-	s.dataMu.RLock()
-	defer s.dataMu.RUnlock()
-
-	if s.remoteData == nil {
-		return []string{}
-	}
-
-	networks := make([]string, 0, len(s.remoteData.Networks))
-
-	for key := range s.remoteData.Networks {
-		if strings.Contains(key, "devnet") {
-			networks = append(networks, key)
-		}
-	}
-
-	return networks
+	return s.devnetsMatching(func(discovery.Network) bool {
+		return true
+	})
 }
 
-// GetNetwork returns information about a specific network.
-func (s *Service) GetNetwork(networkName string) *NetworkInfo {
+// GetNetwork returns information about a specific devnet, or nil if the network
+// is unknown or is not a devnet.
+func (s *Service) GetNetwork(networkName string) *discovery.Network {
 	s.dataMu.RLock()
 	defer s.dataMu.RUnlock()
 
-	if s.remoteData == nil {
-		return nil
-	}
-
-	if network, ok := s.remoteData.Networks[networkName]; ok {
-		if strings.Contains(networkName, "devnet") {
-			return &network
-		}
+	if network, ok := s.networks[networkName]; ok && strings.Contains(networkName, devnet) {
+		return &network
 	}
 
 	return nil
 }
 
-// GetNetworkStatus returns the status of a network.
+// GetNetworkStatus returns the status of a devnet, or an empty string if the
+// network is unknown or is not a devnet.
 func (s *Service) GetNetworkStatus(networkName string) string {
 	s.dataMu.RLock()
 	defer s.dataMu.RUnlock()
 
-	if s.remoteData == nil {
-		return ""
-	}
-
-	if network, ok := s.remoteData.Networks[networkName]; ok {
-		if strings.Contains(networkName, "devnet") {
-			return network.Status
-		}
+	if network, ok := s.networks[networkName]; ok && strings.Contains(networkName, devnet) {
+		return network.Status
 	}
 
 	return ""
-}
-
-// GetNetworksOfType returns all networks of a specific type.
-func (s *Service) GetNetworksOfType(networkType string) []string {
-	s.dataMu.RLock()
-	defer s.dataMu.RUnlock()
-
-	if s.remoteData == nil {
-		return []string{}
-	}
-
-	if metadata, ok := s.remoteData.NetworkMetadata[networkType]; ok {
-		prefix := networkType + "-"
-		networks := make([]string, 0, len(metadata.Stats.NetworkNames))
-
-		for _, name := range metadata.Stats.NetworkNames {
-			networks = append(networks, prefix+name)
-		}
-
-		return networks
-	}
-
-	return []string{}
 }
 
 // GetTeamRoles returns the team roles for a client.
@@ -639,4 +334,102 @@ func (s *Service) GetELClients() []string {
 // GetAdminRoles returns all admin roles.
 func (s *Service) GetAdminRoles() map[string][]string {
 	return clients.AdminRoles
+}
+
+// watch listens for provider update notifications and refreshes the local
+// snapshot until the service is stopped or the context is cancelled.
+func (s *Service) watch(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			s.log.Info("Cartographoor service context done")
+
+			return
+		case <-s.done:
+			return
+		case <-s.provider.NotifyChannel():
+			if err := s.rebuild(ctx); err != nil {
+				s.log.WithError(err).Error("Failed to refresh cartographoor data")
+			}
+		}
+	}
+}
+
+// rebuild refreshes the local snapshot from the provider.
+func (s *Service) rebuild(ctx context.Context) error {
+	networks, err := s.provider.GetNetworks(ctx)
+	if err != nil {
+		return fmt.Errorf("get networks: %w", err)
+	}
+
+	clientList, err := s.provider.GetClients(ctx)
+	if err != nil {
+		return fmt.Errorf("get clients: %w", err)
+	}
+
+	s.dataMu.Lock()
+	s.networks = networks
+	s.clients = clientList
+	s.dataMu.Unlock()
+
+	var (
+		activeDevnets   = 0
+		inactiveDevnets = 0
+	)
+
+	for name, network := range networks {
+		if !strings.Contains(name, devnet) {
+			continue
+		}
+
+		if network.Status == active {
+			activeDevnets++
+		} else {
+			inactiveDevnets++
+		}
+	}
+
+	s.log.WithFields(logrus.Fields{
+		"networks_count":   len(networks),
+		"active_devnets":   activeDevnets,
+		"inactive_devnets": inactiveDevnets,
+		"clients_count":    len(clientList),
+	}).Info("Cartographoor updated")
+
+	return nil
+}
+
+// clientsOfType returns the names of all clients matching the given type.
+func (s *Service) clientsOfType(clientType clients.ClientType) []string {
+	s.dataMu.RLock()
+	defer s.dataMu.RUnlock()
+
+	clientsList := make([]string, 0, len(s.clients))
+
+	for name, c := range s.clients {
+		if c.Type == string(clientType) {
+			clientsList = append(clientsList, name)
+		}
+	}
+
+	return clientsList
+}
+
+// devnetsMatching returns the names of all devnets satisfying the predicate,
+// sorted alphabetically.
+func (s *Service) devnetsMatching(match func(discovery.Network) bool) []string {
+	s.dataMu.RLock()
+	defer s.dataMu.RUnlock()
+
+	networks := make([]string, 0, len(s.networks))
+
+	for key, network := range s.networks {
+		if strings.Contains(key, devnet) && match(network) {
+			networks = append(networks, key)
+		}
+	}
+
+	sort.Strings(networks)
+
+	return networks
 }

--- a/pkg/cartographoor/service_test.go
+++ b/pkg/cartographoor/service_test.go
@@ -97,6 +97,8 @@ func TestCartographoorService(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, service)
 
+	defer service.Stop()
+
 	// Test client data
 	t.Run("Client data", func(t *testing.T) {
 		assert.Equal(t, "ethereum/go-ethereum", service.GetClientRepository("geth"))
@@ -137,11 +139,6 @@ func TestCartographoorService(t *testing.T) {
 		assert.NotContains(t, allNetworks, "sepolia")
 		assert.NotContains(t, allNetworks, "inactive-test")
 
-		// These should still work as expected
-		eofNetworks := service.GetNetworksOfType("eof")
-		assert.Len(t, eofNetworks, 1)
-		assert.Equal(t, "eof-devnet-0", eofNetworks[0])
-
 		// Should return nil for non-devnet networks
 		mainnet := service.GetNetwork("mainnet")
 		assert.Nil(t, mainnet)
@@ -151,11 +148,24 @@ func TestCartographoorService(t *testing.T) {
 		assert.NotNil(t, eofDevnet)
 		assert.Equal(t, "devnet-0", eofDevnet.Name)
 		assert.Equal(t, "active", eofDevnet.Status)
-		assert.Equal(t, int64(7023642286), eofDevnet.ChainID)
+		assert.Equal(t, uint64(7023642286), eofDevnet.ChainID)
 
 		// Status checks should only work for devnet networks
 		assert.Equal(t, "", service.GetNetworkStatus("mainnet"))
 		assert.Equal(t, "active", service.GetNetworkStatus("eof-devnet-0"))
 		assert.Equal(t, "inactive", service.GetNetworkStatus("pectra-devnet-1"))
+	})
+
+	// Test the layer-type aliases and the clients-package delegators.
+	t.Run("Client role delegators", func(t *testing.T) {
+		// GetCLClients/GetELClients alias the consensus/execution getters.
+		assert.ElementsMatch(t, service.GetConsensusClients(), service.GetCLClients())
+		assert.ElementsMatch(t, service.GetExecutionClients(), service.GetELClients())
+
+		// Delegators backed by the clients package; assert they resolve without
+		// panicking and return the package-level data.
+		assert.Equal(t, clients.PreProductionClients["geth"], service.IsPreProductionClient("geth"))
+		assert.Equal(t, clients.TeamRoles["geth"], service.GetTeamRoles("geth"))
+		assert.Equal(t, clients.AdminRoles, service.GetAdminRoles())
 	})
 }

--- a/pkg/cartographoor/service_test.go
+++ b/pkg/cartographoor/service_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethpandaops/panda-pulse/pkg/clients"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )


### PR DESCRIPTION
Replaces panda-pulse's hand-rolled cartographoor fetcher with the [`cartographoor/pkg/client`](https://github.com/ethpandaops/cartographoor/tree/master/pkg/client) library. The bespoke HTTP fetch/parse/refresh loop and its duplicated data models are gone; the package now wraps `client.MemoryProvider` and keeps a thin layer of panda-pulse-specific logic on top.