### PR TITLE
fix(build): lowercase docker tags to match builder behavior

### DIFF
--- a/pkg/discord/cmd/build/image.go
+++ b/pkg/discord/cmd/build/image.go
@@ -33,6 +33,13 @@ var (
 // repo for this workflow, it returns the tag that `prepare.target_tag`
 // produces at runtime.
 func computeBaseDockerTag(repository, ref, dockerTagOverride, upstreamRepository string) string {
+	// The composite action lowercases every input before processing, so the
+	// resulting tag is always lowercase regardless of the branch name casing.
+	repository = strings.ToLower(repository)
+	ref = strings.ToLower(ref)
+	dockerTagOverride = strings.ToLower(dockerTagOverride)
+	upstreamRepository = strings.ToLower(upstreamRepository)
+
 	input := dockerTagOverride
 	if input == "" {
 		input = ref

--- a/pkg/discord/cmd/build/image_test.go
+++ b/pkg/discord/cmd/build/image_test.go
@@ -1,0 +1,75 @@
+package build
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestComputeBaseDockerTag(t *testing.T) {
+	tests := []struct {
+		name               string
+		repository         string
+		ref                string
+		dockerTagOverride  string
+		upstreamRepository string
+		expected           string
+	}{
+		{
+			name:               "uppercase branch name is lowercased",
+			repository:         "bomanaps/grandine",
+			ref:                "feature/FCR",
+			upstreamRepository: "grandinetech/grandine",
+			expected:           "bomanaps-feature-fcr",
+		},
+		{
+			name:               "uppercase docker tag override is lowercased",
+			repository:         "grandinetech/grandine",
+			ref:                "master",
+			dockerTagOverride:  "My-Custom-TAG",
+			upstreamRepository: "grandinetech/grandine",
+			expected:           "my-custom-tag",
+		},
+		{
+			name:               "repository comparison is case-insensitive",
+			repository:         "GrandineTech/Grandine",
+			ref:                "master",
+			upstreamRepository: "grandinetech/grandine",
+			expected:           "master",
+		},
+		{
+			name:               "fork prefix is lowercased",
+			repository:         "BomanAps/grandine",
+			ref:                "fix/bug#123",
+			upstreamRepository: "grandinetech/grandine",
+			expected:           "bomanaps-fix-bug-123",
+		},
+		{
+			name:               "no prefix when override is set",
+			repository:         "bomanaps/grandine",
+			ref:                "feature/FCR",
+			dockerTagOverride:  "custom",
+			upstreamRepository: "grandinetech/grandine",
+			expected:           "custom",
+		},
+		{
+			name:               "leading dashes trimmed after sanitization",
+			repository:         "grandinetech/grandine",
+			ref:                "/Fix",
+			upstreamRepository: "grandinetech/grandine",
+			expected:           "fix",
+		},
+		{
+			name:     "empty input returns empty",
+			ref:      "",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := computeBaseDockerTag(tt.repository, tt.ref, tt.dockerTagOverride, tt.upstreamRepository)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The Discord build notification reported image tags that preserve the branch name's casing (e.g. `ethpandaops/grandine:bomanaps-feature-FCR`), but the `docker-tag` composite action in eth-client-docker-image-builder lowercases all inputs via `tr '[:upper:]' '[:lower:]'` before generating the tag — so the actual pushed tag is `bomanaps-feature-fcr` and the reported reference doesn't exist on Docker Hub.

This updates `computeBaseDockerTag` to mirror the action exactly:
- lowercase `repository`, `ref`, `docker_tag` override, and `upstream_repository` before processing
- as a consequence, the fork-prefix repo comparison becomes case-insensitive, also matching the action

## Test plan
- Added `image_test.go` covering the reported case (`feature/FCR` → `bomanaps-feature-fcr`), override lowercasing, case-insensitive repo comparison, and existing sanitization behavior
- `go test ./pkg/discord/cmd/build/` passes